### PR TITLE
Upgrade to 6.2.4

### DIFF
--- a/pkg/graphs/resource_models/Actor.json
+++ b/pkg/graphs/resource_models/Actor.json
@@ -29,7 +29,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Title",
                     "nodegroup_id": "14c19f18-430a-11ec-934a-080027c2283b",
                     "sortorder": 2,
@@ -61,7 +61,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Correspondence",
                     "nodegroup_id": "167ab58a-3e3f-11ec-934a-080027c2283b",
                     "sortorder": 8,
@@ -157,7 +157,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Inspector Information",
                     "nodegroup_id": "a591c2a6-32a8-11ec-82e5-080027c2283b",
                     "sortorder": 7,
@@ -509,6 +509,7 @@
                 {
                     "card_id": "71bf0b76-30f9-11ec-82e5-080027c2283b",
                     "config": {
+                        "defaultResourceInstance": [],
                         "label": "Related Contact",
                         "placeholder": ""
                     },
@@ -916,23 +917,25 @@
             "functions_x_graphs": [
                 {
                     "config": {
-                        "description": {
-                            "nodegroup_id": "eec41032-22d6-11ec-82e5-080027c2283b",
-                            "string_template": "<Actor Type>"
-                        },
-                        "map_popup": {
-                            "nodegroup_id": "",
-                            "string_template": ""
-                        },
-                        "name": {
-                            "nodegroup_id": "f024722e-2230-11ec-82e5-080027c2283b",
-                            "string_template": "<Name>"
+                        "descriptor_types": {
+                            "description": {
+                                "nodegroup_id": "eec41032-22d6-11ec-82e5-080027c2283b",
+                                "string_template": "<Actor Type>"
+                            },
+                            "map_popup": {
+                                "nodegroup_id": "",
+                                "string_template": ""
+                            },
+                            "name": {
+                                "nodegroup_id": "f024722e-2230-11ec-82e5-080027c2283b",
+                                "string_template": "<Name>"
+                            }
                         },
                         "triggering_nodegroups": []
                     },
                     "function_id": "60000000-0000-0000-0000-000000000001",
                     "graph_id": "e5441dd9-222f-11ec-82e5-080027c2283b",
-                    "id": "2e88e21f-30f2-11ec-82e5-080027c2283b"
+                    "id": "00e25e73-5928-11ec-a804-ddb67dfceb92"
                 }
             ],
             "graphid": "e5441dd9-222f-11ec-82e5-080027c2283b",
@@ -1539,9 +1542,9 @@
         }
     ],
     "metadata": {
-        "db": "PostgreSQL 12.8 (Ubuntu 12.8-1.pgdg18.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0, 64-bit",
-        "git hash": "439f58509 2021-10-26 14:45:09 -0700",
+        "db": "PostgreSQL 12.15 (Ubuntu 12.15-1.pgdg20.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0, 64-bit",
+        "git hash": "fatal: detected dubious ownership in repository at '/opt/app/arches'",
         "os": "Linux",
-        "os version": "4.15.0-158-generic"
+        "os version": "6.2.9-x86_64-linode160"
     }
 }

--- a/pkg/graphs/resource_models/Advocacy.json
+++ b/pkg/graphs/resource_models/Advocacy.json
@@ -93,7 +93,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Contacts",
                     "nodegroup_id": "5b4a3fe8-3690-11ec-934a-080027c2283b",
                     "sortorder": 7,
@@ -151,7 +151,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Tags",
                     "nodegroup_id": "712e5142-3c02-11ec-934a-080027c2283b",
                     "sortorder": 8,
@@ -215,7 +215,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Threat",
                     "nodegroup_id": "c4db22e8-368f-11ec-934a-080027c2283b",
                     "sortorder": 5,
@@ -844,23 +844,25 @@
             "functions_x_graphs": [
                 {
                     "config": {
-                        "description": {
-                            "nodegroup_id": "d3f6d80c-3690-11ec-934a-080027c2283b",
-                            "string_template": "<Status>"
-                        },
-                        "map_popup": {
-                            "nodegroup_id": "d3f6d80c-3690-11ec-934a-080027c2283b",
-                            "string_template": "<Status>"
-                        },
-                        "name": {
-                            "nodegroup_id": "9a55a994-368f-11ec-934a-080027c2283b",
-                            "string_template": "<Project Name>"
+                        "descriptor_types": {
+                            "description": {
+                                "nodegroup_id": "d3f6d80c-3690-11ec-934a-080027c2283b",
+                                "string_template": "<Status>"
+                            },
+                            "map_popup": {
+                                "nodegroup_id": "d3f6d80c-3690-11ec-934a-080027c2283b",
+                                "string_template": "<Status>"
+                            },
+                            "name": {
+                                "nodegroup_id": "9a55a994-368f-11ec-934a-080027c2283b",
+                                "string_template": "<Project Name>"
+                            }
                         },
                         "triggering_nodegroups": []
                     },
                     "function_id": "60000000-0000-0000-0000-000000000001",
                     "graph_id": "2ebb83cb-368f-11ec-934a-080027c2283b",
-                    "id": "d27dc7ee-3b21-11ec-934a-080027c2283b"
+                    "id": "02eaf357-5928-11ec-a804-ddb67dfceb92"
                 }
             ],
             "graphid": "2ebb83cb-368f-11ec-934a-080027c2283b",
@@ -890,7 +892,7 @@
                     "parentnodegroup_id": null
                 },
                 {
-                    "cardinality": "1",
+                    "cardinality": "n",
                     "legacygroupid": null,
                     "nodegroupid": "7019a203-368f-11ec-934a-080027c2283b",
                     "parentnodegroup_id": null
@@ -1384,9 +1386,9 @@
         }
     ],
     "metadata": {
-        "db": "PostgreSQL 12.8 (Ubuntu 12.8-1.pgdg18.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0, 64-bit",
-        "git hash": "439f58509 2021-10-26 14:45:09 -0700",
+        "db": "PostgreSQL 12.15 (Ubuntu 12.15-1.pgdg20.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0, 64-bit",
+        "git hash": "fatal: detected dubious ownership in repository at '/opt/app/arches'",
         "os": "Linux",
-        "os version": "4.15.0-158-generic"
+        "os version": "6.2.9-x86_64-linode160"
     }
 }

--- a/pkg/graphs/resource_models/Easement Inspection.json
+++ b/pkg/graphs/resource_models/Easement Inspection.json
@@ -16,7 +16,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Grounds",
                     "nodegroup_id": "24598818-22ef-11ec-82e5-080027c2283b",
                     "sortorder": 1,
@@ -48,7 +48,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Inspection Context",
                     "nodegroup_id": "2e02039c-3102-11ec-82e5-080027c2283b",
                     "sortorder": 1,
@@ -74,7 +74,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Feature",
                     "nodegroup_id": "c3b8c00e-22ef-11ec-82e5-080027c2283b",
                     "sortorder": null,
@@ -106,7 +106,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Room",
                     "nodegroup_id": "b526a8ec-22ec-11ec-82e5-080027c2283b",
                     "sortorder": 2,
@@ -132,7 +132,7 @@
                     "helptext": "<p>This is where you can record all the observations you make of a particular building on the easement property.</p>\n\n<p>Because some easements have multiple buildings to inspect, you can add as many buildings as you need. In the &quot;Building Name&quot; field, identify which building being observed.</p>\n\n<p>Enter observations for Roofs &amp; Chimneys and each Facade.</p>\n",
                     "helptitle": "Building Observation Help",
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Building",
                     "nodegroup_id": "5ea38782-22ec-11ec-82e5-080027c2283b",
                     "sortorder": 0,
@@ -151,7 +151,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Fa\u00e7ades",
                     "nodegroup_id": "5ea38785-22ec-11ec-82e5-080027c2283b",
                     "sortorder": 1,
@@ -183,7 +183,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Inspection Summary",
                     "nodegroup_id": "8662f9dc-3103-11ec-82e5-080027c2283b",
                     "sortorder": 2,
@@ -215,7 +215,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Observations",
                     "nodegroup_id": "9cad5a04-22e7-11ec-82e5-080027c2283b",
                     "sortorder": 3,
@@ -234,7 +234,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Roofs and Chimneys",
                     "nodegroup_id": "5ea3877f-22ec-11ec-82e5-080027c2283b",
                     "sortorder": 0,
@@ -266,7 +266,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Signed Agreement",
                     "nodegroup_id": "fceeadf2-22e5-11ec-82e5-080027c2283b",
                     "sortorder": 4,
@@ -946,6 +946,7 @@
                 {
                     "card_id": "2e02039e-3102-11ec-82e5-080027c2283b",
                     "config": {
+                        "defaultResourceInstance": [],
                         "label": "Easement",
                         "placeholder": ""
                     },
@@ -959,6 +960,7 @@
                 {
                     "card_id": "2e02039e-3102-11ec-82e5-080027c2283b",
                     "config": {
+                        "defaultResourceInstance": [],
                         "label": "Inspector",
                         "placeholder": ""
                     },
@@ -990,6 +992,7 @@
                 {
                     "card_id": "2e02039e-3102-11ec-82e5-080027c2283b",
                     "config": {
+                        "defaultResourceInstance": [],
                         "label": "Stakeholders Present",
                         "placeholder": ""
                     },
@@ -1529,28 +1532,30 @@
             "functions_x_graphs": [
                 {
                     "config": {
-                        "description": {
-                            "nodegroup_id": "8662f9dc-3103-11ec-82e5-080027c2283b",
-                            "string_template": "<Flag>,  <Overall Rating>, <General Condition>, <Recommendations>"
-                        },
-                        "map_popup": {
-                            "nodegroup_id": "8662f9dc-3103-11ec-82e5-080027c2283b",
-                            "string_template": "<Flag>, <Overall Rating>, <General Condition>, <Recommendations>"
-                        },
-                        "name": {
-                            "nodegroup_id": "2e02039c-3102-11ec-82e5-080027c2283b",
-                            "string_template": "<Easement>,  <Inspection Date>"
+                        "descriptor_types": {
+                            "description": {
+                                "nodegroup_id": "8662f9dc-3103-11ec-82e5-080027c2283b",
+                                "string_template": "<Flag>,  <Overall Rating>, <General Condition>, <Recommendations>"
+                            },
+                            "map_popup": {
+                                "nodegroup_id": "8662f9dc-3103-11ec-82e5-080027c2283b",
+                                "string_template": "<Flag>, <Overall Rating>, <General Condition>, <Recommendations>"
+                            },
+                            "name": {
+                                "nodegroup_id": "2e02039c-3102-11ec-82e5-080027c2283b",
+                                "string_template": "<Easement>,  <Inspection Date>"
+                            }
                         },
                         "triggering_nodegroups": []
                     },
                     "function_id": "60000000-0000-0000-0000-000000000001",
                     "graph_id": "06642595-22e4-11ec-82e5-080027c2283b",
-                    "id": "579715c3-3106-11ec-82e5-080027c2283b"
+                    "id": "06e907e2-5928-11ec-a804-ddb67dfceb92"
                 }
             ],
             "graphid": "06642595-22e4-11ec-82e5-080027c2283b",
             "iconclass": "fa fa-stethoscope",
-            "is_editable": true,
+            "is_editable": false,
             "isactive": true,
             "isresource": true,
             "jsonldcontext": null,
@@ -2551,9 +2556,9 @@
         }
     ],
     "metadata": {
-        "db": "PostgreSQL 12.8 (Ubuntu 12.8-1.pgdg18.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0, 64-bit",
-        "git hash": "439f58509 2021-10-26 14:45:09 -0700",
+        "db": "PostgreSQL 12.15 (Ubuntu 12.15-1.pgdg20.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0, 64-bit",
+        "git hash": "fatal: detected dubious ownership in repository at '/opt/app/arches'",
         "os": "Linux",
-        "os version": "4.15.0-158-generic"
+        "os version": "6.2.9-x86_64-linode160"
     }
 }

--- a/pkg/graphs/resource_models/Easement.json
+++ b/pkg/graphs/resource_models/Easement.json
@@ -5,6 +5,25 @@
             "cards": [
                 {
                     "active": true,
+                    "cardid": "0a16122a-eb4e-11ec-937b-2fecbf82977d",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "c3646da3-2140-11ec-82e5-080027c2283b",
+                    "helpenabled": false,
+                    "helptext": null,
+                    "helptitle": null,
+                    "instructions": null,
+                    "is_editable": true,
+                    "name": "New Node",
+                    "nodegroup_id": "0a161228-eb4e-11ec-937b-2fecbf82977d",
+                    "sortorder": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "253770a0-221b-11ec-82e5-080027c2283b",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -29,7 +48,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": "",
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Designation",
                     "nodegroup_id": "2537709e-221b-11ec-82e5-080027c2283b",
                     "sortorder": 10,
@@ -55,7 +74,7 @@
                     "helptext": "<p>This card holds all of the information necessary to locate the physical, legal document in which the conservation easement is recorded.</p>\n\n<p>Conservation easements are recorded like deeds.In Utah, each county has a recorder&#39;s office. The County Recorder records and maintains all&nbsp;documents pertaining to real estate property in their county&nbsp; and maintains cross-reference indexes to these records. The Recorder&#39;s Office is also required to maintain a set of maps which show the current ownership of every tract of land in the entire county.</p>\n\n<p>Documents such as deeds and conservation easements are cited using a standard system of identifying the County Recorder, the Book, and the starting page on which the document begins.</p>\n\n<p>For example, Duchesne County Book 18 Page 452 may commonly be abbreviated as Duchesne 18/452. If you have a citation like the latter, the number before the / is the Book and the number after the slash is the page number.</p>\n\n<p>Even if the document is multiple pages, only list the first page.</p>\n",
                     "helptitle": "Easement Legal Documentation Help",
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Easement Legal Documentation",
                     "nodegroup_id": "2ba3a4d5-21fd-11ec-82e5-080027c2283b",
                     "sortorder": 3,
@@ -119,7 +138,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Photo",
                     "nodegroup_id": "5a39889a-21fd-11ec-82e5-080027c2283b",
                     "sortorder": 8,
@@ -145,7 +164,7 @@
                     "helptext": "<p>This card holds all of the information necessary to locate the physical, legal document in which the conservation easement&#39;s amendment is recorded.</p>\n\n<p>Conservation easements are recorded like deeds.In Utah, each county has a recorder&#39;s office. The County Recorder records and maintains all&nbsp;documents pertaining to real estate property in their county&nbsp; and maintains cross-reference indexes to these records. The Recorder&#39;s Office is also required to maintain a set of maps which show the current ownership of every tract of land in the entire county.</p>\n\n<p>Documents such as deeds and conservation easements are cited using a standard system of identifying the County Recorder, the Book, and the starting page on which the document begins.</p>\n\n<p>For example, Duchesne County Book 18 Page 452 may commonly be abbreviated as Duchesne 18/452. If you have a citation like the latter, the number before the / is the Book and the number after the slash is the page number.</p>\n\n<p>Even if the document is multiple pages, only list the first page.</p>\n",
                     "helptitle": "Easement Amendments Help",
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Amendments",
                     "nodegroup_id": "63cb238d-21fd-11ec-82e5-080027c2283b",
                     "sortorder": 4,
@@ -209,7 +228,7 @@
                     "helptext": "<p>Why was this property important to conserve? The statement of significance is an opportunity to document the justification for the conservation easement and to communicate to the public why this property is special.</p>\n\n<p>In cases where the property is on the state or national register, you may want to refer to its narrative statement of significance as recorded by the relevant agencies.</p>\n",
                     "helptitle": "Statement of Significance Help",
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Statement of Significance",
                     "nodegroup_id": "84a1f9e8-3047-11ec-82e5-080027c2283b",
                     "sortorder": 11,
@@ -299,7 +318,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Property Description",
                     "nodegroup_id": "de73731e-328d-11ec-82e5-080027c2283b",
                     "sortorder": 5,
@@ -392,7 +411,7 @@
                     "helptext": "<p>This is where you may enter all of the functions that you have been able to document about this property.&nbsp;</p>\n\n<p>Functions may either be &quot;current&quot; (i.e. the property is still used for this purpose) or &quot;historic&quot; (i.e. the property once was used for this purpose, but is no longer.)</p>\n\n<p>There may be multiple current functions as well as multple historic functions. You may expand upon some of these functions in the property&#39;s statement of significance.</p>\n\n<p>For instance, the Old Post Office in Washington DC would have a current function of hotel, but several historic functions, including post office, and government office.</p>\n",
                     "helptitle": "Property Function Help",
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Function",
                     "nodegroup_id": "faae8d6f-3046-11ec-82e5-080027c2283b",
                     "sortorder": 7,
@@ -648,6 +667,7 @@
                 {
                     "card_id": "8e3ae382-2236-11ec-82e5-080027c2283b",
                     "config": {
+                        "defaultResourceInstance": [],
                         "label": "Entity",
                         "placeholder": ""
                     },
@@ -1243,6 +1263,15 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "c3646da2-2140-11ec-82e5-080027c2283b",
+                    "edgeid": "0a16122b-eb4e-11ec-937b-2fecbf82977d",
+                    "graph_id": "c3646da3-2140-11ec-82e5-080027c2283b",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P136i_supported_type_creation",
+                    "rangenode_id": "0a161228-eb4e-11ec-937b-2fecbf82977d"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "382a829c-425d-11ec-934a-080027c2283b",
                     "edgeid": "0a9a4249-4318-11ec-934a-080027c2283b",
                     "graph_id": "c3646da3-2140-11ec-82e5-080027c2283b",
@@ -1677,23 +1706,25 @@
             "functions_x_graphs": [
                 {
                     "config": {
-                        "description": {
-                            "nodegroup_id": "b8676495-3046-11ec-82e5-080027c2283b",
-                            "string_template": "Easement on <Feature Type>, Built: <Built Date><p><Architectural Style></p><p><Material></p>"
-                        },
-                        "map_popup": {
-                            "nodegroup_id": "b8676495-3046-11ec-82e5-080027c2283b",
-                            "string_template": "Easement on <Feature Type>, Built: <Built Date><p><Architectural Style></p><p><Material></p>"
-                        },
-                        "name": {
-                            "nodegroup_id": "e7bd68ea-21fc-11ec-82e5-080027c2283b",
-                            "string_template": "<Property Name>"
+                        "descriptor_types": {
+                            "description": {
+                                "nodegroup_id": "b8676495-3046-11ec-82e5-080027c2283b",
+                                "string_template": "Easement on <Feature Type>, Built: <Built Date><p><Architectural Style></p><p><Material></p>"
+                            },
+                            "map_popup": {
+                                "nodegroup_id": "b8676495-3046-11ec-82e5-080027c2283b",
+                                "string_template": "Easement on <Feature Type>, Built: <Built Date><p><Architectural Style></p><p><Material></p>"
+                            },
+                            "name": {
+                                "nodegroup_id": "e7bd68ea-21fc-11ec-82e5-080027c2283b",
+                                "string_template": "<Property Name>"
+                            }
                         },
                         "triggering_nodegroups": []
                     },
                     "function_id": "60000000-0000-0000-0000-000000000001",
                     "graph_id": "c3646da3-2140-11ec-82e5-080027c2283b",
-                    "id": "111a604f-2c3e-11ec-82e5-080027c2283b"
+                    "id": "77c9c488-592a-11ec-a804-ddb67dfceb92"
                 }
             ],
             "graphid": "c3646da3-2140-11ec-82e5-080027c2283b",
@@ -1704,6 +1735,12 @@
             "jsonldcontext": null,
             "name": "Easement",
             "nodegroups": [
+                {
+                    "cardinality": "1",
+                    "legacygroupid": null,
+                    "nodegroupid": "0a161228-eb4e-11ec-937b-2fecbf82977d",
+                    "parentnodegroup_id": null
+                },
                 {
                     "cardinality": "n",
                     "legacygroupid": null,
@@ -1848,6 +1885,24 @@
                     "nodeid": "02d677fc-21fd-11ec-82e5-080027c2283b",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0
+                },
+                {
+                    "config": null,
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "c3646da3-2140-11ec-82e5-080027c2283b",
+                    "is_collector": true,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "New Node",
+                    "nodegroup_id": "0a161228-eb4e-11ec-937b-2fecbf82977d",
+                    "nodeid": "0a161228-eb4e-11ec-937b-2fecbf82977d",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E83_Type_Creation",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P136i_supported_type_creation",
                     "sortorder": 0
                 },
                 {
@@ -2874,9 +2929,9 @@
         }
     ],
     "metadata": {
-        "db": "PostgreSQL 12.8 (Ubuntu 12.8-1.pgdg18.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0, 64-bit",
-        "git hash": "439f58509 2021-10-26 14:45:09 -0700",
+        "db": "PostgreSQL 12.15 (Ubuntu 12.15-1.pgdg20.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0, 64-bit",
+        "git hash": "fatal: detected dubious ownership in repository at '/opt/app/arches'",
         "os": "Linux",
-        "os version": "4.15.0-158-generic"
+        "os version": "6.2.9-x86_64-linode160"
     }
 }

--- a/pkg/graphs/resource_models/Preservation Directory.json
+++ b/pkg/graphs/resource_models/Preservation Directory.json
@@ -29,7 +29,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Year Established",
                     "nodegroup_id": "3195c412-335f-11ec-934a-080027c2283b",
                     "sortorder": 2,
@@ -1014,23 +1014,25 @@
             "functions_x_graphs": [
                 {
                     "config": {
-                        "description": {
-                            "nodegroup_id": "59c106be-335e-11ec-934a-080027c2283b",
-                            "string_template": "Specialization: <Specialization>, Additional Services: <Additional Services>"
-                        },
-                        "map_popup": {
-                            "nodegroup_id": "59c106be-335e-11ec-934a-080027c2283b",
-                            "string_template": "Specialization: <Specialization>, Additional Services: <Additional Services>"
-                        },
-                        "name": {
-                            "nodegroup_id": "370604e0-335d-11ec-934a-080027c2283b",
-                            "string_template": "<Business Name>"
+                        "descriptor_types": {
+                            "description": {
+                                "nodegroup_id": "59c106be-335e-11ec-934a-080027c2283b",
+                                "string_template": "Specialization: <Specialization>, Additional Services: <Additional Services>"
+                            },
+                            "map_popup": {
+                                "nodegroup_id": "59c106be-335e-11ec-934a-080027c2283b",
+                                "string_template": "Specialization: <Specialization>, Additional Services: <Additional Services>"
+                            },
+                            "name": {
+                                "nodegroup_id": "370604e0-335d-11ec-934a-080027c2283b",
+                                "string_template": "<Business Name>"
+                            }
                         },
                         "triggering_nodegroups": []
                     },
                     "function_id": "60000000-0000-0000-0000-000000000001",
                     "graph_id": "56fb370a-335a-11ec-934a-080027c2283b",
-                    "id": "58b78ee0-335a-11ec-934a-080027c2283b"
+                    "id": "04861a62-5928-11ec-a804-ddb67dfceb92"
                 }
             ],
             "graphid": "56fb370a-335a-11ec-934a-080027c2283b",
@@ -1769,9 +1771,9 @@
         }
     ],
     "metadata": {
-        "db": "PostgreSQL 12.8 (Ubuntu 12.8-1.pgdg18.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0, 64-bit",
-        "git hash": "439f58509 2021-10-26 14:45:09 -0700",
+        "db": "PostgreSQL 12.15 (Ubuntu 12.15-1.pgdg20.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0, 64-bit",
+        "git hash": "fatal: detected dubious ownership in repository at '/opt/app/arches'",
         "os": "Linux",
-        "os version": "4.15.0-158-generic"
+        "os version": "6.2.9-x86_64-linode160"
     }
 }

--- a/pkg/graphs/resource_models/Revolving Loan.json
+++ b/pkg/graphs/resource_models/Revolving Loan.json
@@ -74,7 +74,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Photo",
                     "nodegroup_id": "2e1ec9ff-3bfd-11ec-934a-080027c2283b",
                     "sortorder": 5,
@@ -170,7 +170,7 @@
                     "helptext": null,
                     "helptitle": null,
                     "instructions": null,
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": "Loan Document",
                     "nodegroup_id": "9b7acc12-3696-11ec-934a-080027c2283b",
                     "sortorder": 3,
@@ -486,7 +486,8 @@
                         "defaultValue": "",
                         "label": "Loan Fund",
                         "maxLength": null,
-                        "placeholder": "Enter text",
+                        "options": [],
+                        "placeholder": "Choose a fund",
                         "uneditable": false,
                         "width": "100%"
                     },
@@ -495,7 +496,7 @@
                     "node_id": "7f04716e-3696-11ec-934a-080027c2283b",
                     "sortorder": 5,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
                     "card_id": "72a2f3d8-3e44-11ec-934a-080027c2283b",
@@ -745,23 +746,25 @@
             "functions_x_graphs": [
                 {
                     "config": {
-                        "description": {
-                            "nodegroup_id": "4368ab9e-3695-11ec-934a-080027c2283b",
-                            "string_template": "<Year>, $<Amount>, <Loan Fund>"
-                        },
-                        "map_popup": {
-                            "nodegroup_id": "4368ab9e-3695-11ec-934a-080027c2283b",
-                            "string_template": "<Year>, $<Amount>, <Loan Fund>"
-                        },
-                        "name": {
-                            "nodegroup_id": "0503e031-3695-11ec-934a-080027c2283b",
-                            "string_template": "<Property Street Address>,  <City>"
+                        "descriptor_types": {
+                            "description": {
+                                "nodegroup_id": "4368ab9e-3695-11ec-934a-080027c2283b",
+                                "string_template": "<Year Initiated>, $<Amount>, Fund: <Loan Fund>"
+                            },
+                            "map_popup": {
+                                "nodegroup_id": "4368ab9e-3695-11ec-934a-080027c2283b",
+                                "string_template": "<Year Initiated>, $<Amount>, Fund: <Loan Fund>"
+                            },
+                            "name": {
+                                "nodegroup_id": "0503e031-3695-11ec-934a-080027c2283b",
+                                "string_template": "<Property Street Address>,  <City>"
+                            }
                         },
                         "triggering_nodegroups": []
                     },
                     "function_id": "60000000-0000-0000-0000-000000000001",
                     "graph_id": "b31e58cd-3694-11ec-934a-080027c2283b",
-                    "id": "f95aa551-3696-11ec-934a-080027c2283b"
+                    "id": "05d98730-5928-11ec-a804-ddb67dfceb92"
                 }
             ],
             "graphid": "b31e58cd-3694-11ec-934a-080027c2283b",
@@ -1299,9 +1302,9 @@
         }
     ],
     "metadata": {
-        "db": "PostgreSQL 12.8 (Ubuntu 12.8-1.pgdg18.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0, 64-bit",
-        "git hash": "439f58509 2021-10-26 14:45:09 -0700",
+        "db": "PostgreSQL 12.15 (Ubuntu 12.15-1.pgdg20.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0, 64-bit",
+        "git hash": "fatal: detected dubious ownership in repository at '/opt/app/arches'",
         "os": "Linux",
-        "os version": "4.15.0-158-generic"
+        "os version": "6.2.9-x86_64-linode160"
     }
 }

--- a/presutah/media/js/leaflet-side-by-side.js
+++ b/presutah/media/js/leaflet-side-by-side.js
@@ -1,0 +1,270 @@
+(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+(function (global){
+var L = (typeof window !== "undefined" ? window['L'] : typeof global !== "undefined" ? global['L'] : null)
+require('./layout.css')
+require('./range.css')
+
+var mapWasDragEnabled
+var mapWasTapEnabled
+
+// Leaflet v0.7 backwards compatibility
+function on (el, types, fn, context) {
+  types.split(' ').forEach(function (type) {
+    L.DomEvent.on(el, type, fn, context)
+  })
+}
+
+// Leaflet v0.7 backwards compatibility
+function off (el, types, fn, context) {
+  types.split(' ').forEach(function (type) {
+    L.DomEvent.off(el, type, fn, context)
+  })
+}
+
+function getRangeEvent (rangeInput) {
+  return 'oninput' in rangeInput ? 'input' : 'change'
+}
+
+function cancelMapDrag () {
+  mapWasDragEnabled = this._map.dragging.enabled()
+  mapWasTapEnabled = this._map.tap && this._map.tap.enabled()
+  this._map.dragging.disable()
+  this._map.tap && this._map.tap.disable()
+}
+
+function uncancelMapDrag (e) {
+  this._refocusOnMap(e)
+  if (mapWasDragEnabled) {
+    this._map.dragging.enable()
+  }
+  if (mapWasTapEnabled) {
+    this._map.tap.enable()
+  }
+}
+
+// convert arg to an array - returns empty array if arg is undefined
+function asArray (arg) {
+  return (arg === 'undefined') ? [] : Array.isArray(arg) ? arg : [arg]
+}
+
+function noop () {}
+
+L.Control.SideBySide = L.Control.extend({
+  options: {
+    thumbSize: 42,
+    padding: 0
+  },
+
+  initialize: function (leftLayers, rightLayers, options) {
+    this.setLeftLayers(leftLayers)
+    this.setRightLayers(rightLayers)
+    L.setOptions(this, options)
+  },
+
+  getPosition: function () {
+    var rangeValue = this._range.value
+    var offset = (0.5 - rangeValue) * (2 * this.options.padding + this.options.thumbSize)
+    return this._map.getSize().x * rangeValue + offset
+  },
+
+  setPosition: noop,
+
+  includes: L.Evented.prototype || L.Mixin.Events,
+
+  addTo: function (map) {
+    this.remove()
+    this._map = map
+
+    var container = this._container = L.DomUtil.create('div', 'leaflet-sbs', map._controlContainer)
+
+    this._divider = L.DomUtil.create('div', 'leaflet-sbs-divider', container)
+    var range = this._range = L.DomUtil.create('input', 'leaflet-sbs-range', container)
+    range.type = 'range'
+    range.min = 0
+    range.max = 1
+    range.step = 'any'
+    range.value = 0.5
+    range.style.paddingLeft = range.style.paddingRight = this.options.padding + 'px'
+    this._addEvents()
+    this._updateLayers()
+    return this
+  },
+
+  remove: function () {
+    if (!this._map) {
+      return this
+    }
+    if (this._leftLayer) {
+      this._leftLayer.getContainer().style.clip = ''
+    }
+    if (this._rightLayer) {
+      this._rightLayer.getContainer().style.clip = ''
+    }
+    this._removeEvents()
+    L.DomUtil.remove(this._container)
+
+    this._map = null
+
+    return this
+  },
+
+  setLeftLayers: function (leftLayers) {
+    this._leftLayers = asArray(leftLayers)
+    this._updateLayers()
+    return this
+  },
+
+  setRightLayers: function (rightLayers) {
+    this._rightLayers = asArray(rightLayers)
+    this._updateLayers()
+    return this
+  },
+
+  _updateClip: function () {
+    var map = this._map
+    var nw = map.containerPointToLayerPoint([0, 0])
+    var se = map.containerPointToLayerPoint(map.getSize())
+    var clipX = nw.x + this.getPosition()
+    var dividerX = this.getPosition()
+
+    this._divider.style.left = dividerX + 'px'
+    this.fire('dividermove', {x: dividerX})
+    var clipLeft = 'rect(' + [nw.y, clipX, se.y, nw.x].join('px,') + 'px)'
+    var clipRight = 'rect(' + [nw.y, se.x, se.y, clipX].join('px,') + 'px)'
+    if (this._leftLayer) {
+      this._leftLayer.getContainer().style.clip = clipLeft
+    }
+    if (this._rightLayer) {
+      this._rightLayer.getContainer().style.clip = clipRight
+    }
+  },
+
+  _updateLayers: function () {
+    if (!this._map) {
+      return this
+    }
+    var prevLeft = this._leftLayer
+    var prevRight = this._rightLayer
+    this._leftLayer = this._rightLayer = null
+    this._leftLayers.forEach(function (layer) {
+      if (this._map.hasLayer(layer)) {
+        this._leftLayer = layer
+      }
+    }, this)
+    this._rightLayers.forEach(function (layer) {
+      if (this._map.hasLayer(layer)) {
+        this._rightLayer = layer
+      }
+    }, this)
+    if (prevLeft !== this._leftLayer) {
+      prevLeft && this.fire('leftlayerremove', {layer: prevLeft})
+      this._leftLayer && this.fire('leftlayeradd', {layer: this._leftLayer})
+    }
+    if (prevRight !== this._rightLayer) {
+      prevRight && this.fire('rightlayerremove', {layer: prevRight})
+      this._rightLayer && this.fire('rightlayeradd', {layer: this._rightLayer})
+    }
+    this._updateClip()
+  },
+
+  _addEvents: function () {
+    var range = this._range
+    var map = this._map
+    if (!map || !range) return
+    map.on('move', this._updateClip, this)
+    map.on('layeradd layerremove', this._updateLayers, this)
+    on(range, getRangeEvent(range), this._updateClip, this)
+    on(range, L.Browser.touch ? 'touchstart' : 'mousedown', cancelMapDrag, this)
+    on(range, L.Browser.touch ? 'touchend' : 'mouseup', uncancelMapDrag, this)
+  },
+
+  _removeEvents: function () {
+    var range = this._range
+    var map = this._map
+    if (range) {
+      off(range, getRangeEvent(range), this._updateClip, this)
+      off(range, L.Browser.touch ? 'touchstart' : 'mousedown', cancelMapDrag, this)
+      off(range, L.Browser.touch ? 'touchend' : 'mouseup', uncancelMapDrag, this)
+    }
+    if (map) {
+      map.off('layeradd layerremove', this._updateLayers, this)
+      map.off('move', this._updateClip, this)
+    }
+  }
+})
+
+L.control.sideBySide = function (leftLayers, rightLayers, options) {
+  return new L.Control.SideBySide(leftLayers, rightLayers, options)
+}
+
+module.exports = L.Control.SideBySide
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{"./layout.css":2,"./range.css":4}],2:[function(require,module,exports){
+var inject = require('./node_modules/cssify');
+var css = ".leaflet-sbs-range {\r\n    position: absolute;\r\n    top: 50%;\r\n    width: 100%;\r\n    z-index: 999;\r\n}\r\n.leaflet-sbs-divider {\r\n    position: absolute;\r\n    top: 0;\r\n    bottom: 0;\r\n    left: 50%;\r\n    margin-left: -2px;\r\n    width: 4px;\r\n    background-color: #fff;\r\n    pointer-events: none;\r\n    z-index: 999;\r\n}\r\n";
+inject(css, undefined, '_i6aomd');
+module.exports = css;
+
+},{"./node_modules/cssify":3}],3:[function(require,module,exports){
+'use strict'
+
+function injectStyleTag (document, fileName, cb) {
+  var style = document.getElementById(fileName)
+
+  if (style) {
+    cb(style)
+  } else {
+    var head = document.getElementsByTagName('head')[0]
+
+    style = document.createElement('style')
+    if (fileName != null) style.id = fileName
+    cb(style)
+    head.appendChild(style)
+  }
+
+  return style
+}
+
+module.exports = function (css, customDocument, fileName) {
+  var doc = customDocument || document
+  /* istanbul ignore if: not supported by Electron */
+  if (doc.createStyleSheet) {
+    var sheet = doc.createStyleSheet()
+    sheet.cssText = css
+    return sheet.ownerNode
+  } else {
+    return injectStyleTag(doc, fileName, function (style) {
+      /* istanbul ignore if: not supported by Electron */
+      if (style.styleSheet) {
+        style.styleSheet.cssText = css
+      } else {
+        style.innerHTML = css
+      }
+    })
+  }
+}
+
+module.exports.byUrl = function (url) {
+  /* istanbul ignore if: not supported by Electron */
+  if (document.createStyleSheet) {
+    return document.createStyleSheet(url).ownerNode
+  } else {
+    var head = document.getElementsByTagName('head')[0]
+    var link = document.createElement('link')
+
+    link.rel = 'stylesheet'
+    link.href = url
+
+    head.appendChild(link)
+    return link
+  }
+}
+
+},{}],4:[function(require,module,exports){
+var inject = require('./node_modules/cssify');
+var css = ".leaflet-sbs-range {\r\n    -webkit-appearance: none;\r\n    display: inline-block!important;\r\n    vertical-align: middle;\r\n    height: 0;\r\n    padding: 0;\r\n    margin: 0;\r\n    border: 0;\r\n    background: rgba(0, 0, 0, 0.25);\r\n    min-width: 100px;\r\n    cursor: pointer;\r\n    pointer-events: none;\r\n    z-index: 999;\r\n}\r\n.leaflet-sbs-range::-ms-fill-upper {\r\n    background: transparent;\r\n}\r\n.leaflet-sbs-range::-ms-fill-lower {\r\n    background: rgba(255, 255, 255, 0.25);\r\n}\r\n/* Browser thingies */\r\n\r\n.leaflet-sbs-range::-moz-range-track {\r\n    opacity: 0;\r\n}\r\n.leaflet-sbs-range::-ms-track {\r\n    opacity: 0;\r\n}\r\n.leaflet-sbs-range::-ms-tooltip {\r\n    display: none;\r\n}\r\n/* For whatever reason, these need to be defined\r\n * on their own so dont group them */\r\n\r\n.leaflet-sbs-range::-webkit-slider-thumb {\r\n    -webkit-appearance: none;\r\n    margin: 0;\r\n    padding: 0;\r\n    background: #fff;\r\n    height: 40px;\r\n    width: 40px;\r\n    border-radius: 20px;\r\n    cursor: ew-resize;\r\n    pointer-events: auto;\r\n    border: 1px solid #ddd;\r\n    background-image: url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAMAAAC5zwKfAAAABlBMVEV9fX3///+Kct39AAAAAnRSTlP/AOW3MEoAAAA9SURBVFjD7dehDQAwDANBZ/+l2wmKoiqR7pHRcaeaCxAIBAL/g7k9JxAIBAKBQCAQCAQC14H+MhAIBE4CD3fOFvGVBzhZAAAAAElFTkSuQmCC\");\r\n    background-position: 50% 50%;\r\n    background-repeat: no-repeat;\r\n    background-size: 40px 40px;\r\n}\r\n.leaflet-sbs-range::-ms-thumb {\r\n    margin: 0;\r\n    padding: 0;\r\n    background: #fff;\r\n    height: 40px;\r\n    width: 40px;\r\n    border-radius: 20px;\r\n    cursor: ew-resize;\r\n    pointer-events: auto;\r\n    border: 1px solid #ddd;\r\n    background-image: url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAMAAAC5zwKfAAAABlBMVEV9fX3///+Kct39AAAAAnRSTlP/AOW3MEoAAAA9SURBVFjD7dehDQAwDANBZ/+l2wmKoiqR7pHRcaeaCxAIBAL/g7k9JxAIBAKBQCAQCAQC14H+MhAIBE4CD3fOFvGVBzhZAAAAAElFTkSuQmCC\");\r\n    background-position: 50% 50%;\r\n    background-repeat: no-repeat;\r\n    background-size: 40px 40px;\r\n}\r\n.leaflet-sbs-range::-moz-range-thumb {\r\n    padding: 0;\r\n    right: 0    ;\r\n    background: #fff;\r\n    height: 40px;\r\n    width: 40px;\r\n    border-radius: 20px;\r\n    cursor: ew-resize;\r\n    pointer-events: auto;\r\n    border: 1px solid #ddd;\r\n    background-image: url(\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAABQCAMAAAC5zwKfAAAABlBMVEV9fX3///+Kct39AAAAAnRSTlP/AOW3MEoAAAA9SURBVFjD7dehDQAwDANBZ/+l2wmKoiqR7pHRcaeaCxAIBAL/g7k9JxAIBAKBQCAQCAQC14H+MhAIBE4CD3fOFvGVBzhZAAAAAElFTkSuQmCC\");\r\n    background-position: 50% 50%;\r\n    background-repeat: no-repeat;\r\n    background-size: 40px 40px;\r\n}\r\n.leaflet-sbs-range:disabled::-moz-range-thumb {\r\n    cursor: default;\r\n}\r\n.leaflet-sbs-range:disabled::-ms-thumb {\r\n    cursor: default;\r\n}\r\n.leaflet-sbs-range:disabled::-webkit-slider-thumb {\r\n    cursor: default;\r\n}\r\n.leaflet-sbs-range:disabled {\r\n    cursor: default;\r\n}\r\n.leaflet-sbs-range:focus {\r\n    outline: none!important;\r\n}\r\n.leaflet-sbs-range::-moz-focus-outer {\r\n    border: 0;\r\n}\r\n\r\n";
+inject(css, undefined, '_1tlt668');
+module.exports = css;
+
+},{"./node_modules/cssify":3}]},{},[1]);

--- a/presutah/package.json
+++ b/presutah/package.json
@@ -1,6 +1,6 @@
 {
     "name": "presutah",
     "dependencies": {
-        "arches": "archesproject/arches#stable/6.0.0"
+        "arches": "archesproject/arches#stable/6.2.4"
     }
 }

--- a/presutah/settings.py
+++ b/presutah/settings.py
@@ -136,11 +136,14 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 15728640
 # Unique session cookie ensures that logins are treated separately for each app
 SESSION_COOKIE_NAME = 'presutah'
 
-# For more info on configuring your cache: https://docs.djangoproject.com/en/2.2/topics/cache/
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-    }
+    },
+    "user_permission": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "user_permission_cache",
+    },
 }
 
 # Hide nodes and cards in a report that have no data
@@ -242,7 +245,7 @@ LANGUAGE_CODE = "en"
 # a list of language codes can be found here http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGES = [
 #   ('de', _('German')),
-#   ('en', _('English')),
+  ('en', _('English')),
 #   ('en-gb', _('British English')),
 #   ('es', _('Spanish')),
 ]

--- a/presutah/templates/base-manager.htm
+++ b/presutah/templates/base-manager.htm
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 
 {% extends "base.htm" %}
-{% load staticfiles %}
+{% load static %}
 {% load template_tags %}
 {% load i18n %}
 

--- a/presutah/templates/index.htm
+++ b/presutah/templates/index.htm
@@ -15,7 +15,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
-{% load staticfiles %}
+{% load static %}
 {% load template_tags %}
 {% load i18n %}
 <!DOCTYPE html>

--- a/presutah/templates/login.htm
+++ b/presutah/templates/login.htm
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 {% extends "base.htm" %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 
 {% block loading_mask %}

--- a/presutah/templates/views/components/resource-report-abstract.htm
+++ b/presutah/templates/views/components/resource-report-abstract.htm
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 
 <!--ko if: loading() -->

--- a/presutah/templates/views/components/search/directory-search.htm
+++ b/presutah/templates/views/components/search/directory-search.htm
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 <div class="search-container saved-search-container relative" style="overflow-y: scroll;">
 

--- a/presutah/templates/views/search.htm
+++ b/presutah/templates/views/search.htm
@@ -18,7 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 {% extends "base-manager.htm" %}
 {% load i18n %}
 {% load template_tags %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %} {{ block.super }} {% trans "Search" %} {% endblock title %}
 

--- a/presutah/yarn.lock
+++ b/presutah/yarn.lock
@@ -3,30 +3,30 @@
 
 
 "@babel/code-frame@^7.0.0":
-  version "7.15.8"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.15.8.tgz#45990c47adadb00c03677baa89221f7cc23d2503"
-  integrity sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.5.tgz#234d98e1551960604f1246e6475891a570ad5658"
+  integrity sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==
   dependencies:
-    "@babel/highlight" "^7.14.5"
+    "@babel/highlight" "^7.22.5"
 
-"@babel/helper-validator-identifier@^7.14.5":
-  version "7.15.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
-  integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
+"@babel/helper-validator-identifier@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
+  integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
 
-"@babel/highlight@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
-  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
+"@babel/highlight@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.5.tgz#aa6c05c5407a67ebce408162b7ede789b4d22031"
+  integrity sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.14.5"
+    "@babel/helper-validator-identifier" "^7.22.5"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
 "@mapbox/extent@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@mapbox/extent/-/extent-0.4.0.tgz#3e591f32e1f0c3981c864239f7b0ac06e610f8a9"
-  integrity sha1-PlkfMuHww5gchkI597CsBuYQ+Kk=
+  integrity sha512-MSoKw3qPceGuupn04sdaJrFeLKvcSETVLZCGS8JA9x6zXQL3FWiKaIXYIZEDXd5jpXpWlRxinCZIN49yRy0C9A==
 
 "@mapbox/fusspot@^0.4.0":
   version "0.4.0"
@@ -39,40 +39,58 @@
 "@mapbox/geojson-area@^0.2.1", "@mapbox/geojson-area@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz#18d7814aa36bf23fbbcc379f8e26a22927debf10"
-  integrity sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=
+  integrity sha512-bBqqFn1kIbLBfn7Yq1PzzwVkPYQr9lVUeT8Dhd0NL5n76PBuXzOcuLV7GOSbEB1ia8qWxH4COCvFpziEu/yReA==
   dependencies:
     wgs84 "0.0.0"
 
 "@mapbox/geojson-coords@0.0.0":
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-coords/-/geojson-coords-0.0.0.tgz#4847a5b96059666e527a2139e75e35d84fd58f50"
-  integrity sha1-SEeluWBZZm5SeiE551412E/Vj1A=
+  integrity sha512-xCFWhmHWlfthXqZtgip0QqgERIPrwx2EdayDn4VQYYpICEdiIs92SdG/ojYZwaxXGa+fOgcVOuKvSxzdtu3rfA==
   dependencies:
     "@mapbox/geojson-normalize" "0.0.1"
     geojson-flatten "~0.2.1"
 
-"@mapbox/geojson-extent@0.3.2", "@mapbox/geojson-extent@^0.3.2":
+"@mapbox/geojson-coords@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@mapbox/geojson-coords/-/geojson-coords-0.0.2.tgz#f73d5744c832de0f05c48899f16a4288cefb2606"
+  integrity sha512-YuVzpseee/P1T5BWyeVVPppyfmuXYHFwZHmybkqaMfu4BWlOf2cmMGKj2Rr92MwfSTOCSUA0PAsVGRG8akY0rg==
+  dependencies:
+    "@mapbox/geojson-normalize" "0.0.1"
+    geojson-flatten "^1.0.4"
+
+"@mapbox/geojson-extent@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-extent/-/geojson-extent-0.3.2.tgz#a1bdb2015afd0e031c18c3f29f7eb229e4e1950f"
-  integrity sha1-ob2yAVr9DgMcGMPyn36yKeThlQ8=
+  integrity sha512-Wl2al5bU7eYedc0c6SG2Pmfkj2iX3eVj2xUa8RAsR/0iFMiHX4n2j5aHus0EpJVc8T34jr8xWJSjWYVR1oNDMw==
   dependencies:
     "@mapbox/extent" "0.4.0"
     "@mapbox/geojson-coords" "0.0.0"
     rw "~0.1.4"
     traverse "~0.6.6"
 
+"@mapbox/geojson-extent@~1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@mapbox/geojson-extent/-/geojson-extent-1.0.1.tgz#bd99a6b66ba98e63a29511c9cd1bbd1df4c1e203"
+  integrity sha512-hh8LEO3djT4fqfr8sSC6wKt+p0TMiu+KOLMBUiFOyj+zGq7+IXwQGl0ppCVDkyzCewyd9LoGe9zAvDxXrLfhLw==
+  dependencies:
+    "@mapbox/extent" "0.4.0"
+    "@mapbox/geojson-coords" "0.0.2"
+    rw "~0.1.4"
+    traverse "~0.6.6"
+
 "@mapbox/geojson-normalize@0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@mapbox/geojson-normalize/-/geojson-normalize-0.0.1.tgz#1da1e6b3a7add3ad29909b30f438f60581b7cd80"
-  integrity sha1-HaHms6et060pkJsw9Dj2BYG3zYA=
+  integrity sha512-82V7YHcle8lhgIGqEWwtXYN5cy0QM/OHq3ypGhQTbvHR57DF0vMHMjjVSQKFfVXBe/yWCBZTyOuzvK7DFFnx5Q==
 
-"@mapbox/geojson-rewind@^0.5.0":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/geojson-rewind/-/geojson-rewind-0.5.1.tgz#adbe16dc683eb40e90934c51a5e28c7bbf44f4e1"
-  integrity sha512-eL7fMmfTBKjrb+VFHXCGv9Ot0zc3C0U+CwXo1IrP+EPwDczLoXv34Tgq3y+2mPSFNVUXgU42ILWJTC7145KPTA==
+"@mapbox/geojson-rewind@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz#591a5d71a9cd1da1a0bf3420b3bea31b0fc7946a"
+  integrity sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==
   dependencies:
     get-stream "^6.0.1"
-    minimist "^1.2.5"
+    minimist "^1.2.6"
 
 "@mapbox/geojson-types@^1.0.2":
   version "1.0.2"
@@ -91,20 +109,20 @@
     vfile-reporter "^5.1.1"
 
 "@mapbox/geojsonhint@^3.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/geojsonhint/-/geojsonhint-3.0.1.tgz#46eb0afbfb45915efb73650b90ac64dd8b2274ef"
-  integrity sha512-8BhaDcFnTGP9Z8gLWQfeOMMO4xWmJWN45ZITfjiatI5aP9rmRXTaF2ugvCAJQH+llWTuC+/V+c783ApVoSbnsQ==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/geojsonhint/-/geojsonhint-3.2.0.tgz#3bf88d3f22a90dcdebca175c761fb4e8a31a822e"
+  integrity sha512-2gvaeDq0uGZ2jiKsdKBd2u3HJD6h0H1GzDnZjH3nVQHyyig3aNFNrMMqDYn0XipkQvkKGU96Y971qsJM1qpDdw==
   dependencies:
     concat-stream "^1.6.1"
     jsonlint-lines "1.7.1"
-    minimist "^1.2.5"
+    minimist "^1.2.8"
     vfile "^4.0.0"
     vfile-reporter "^5.1.1"
 
 "@mapbox/jsonlint-lines-primitives@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
-  integrity sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=
+  integrity sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==
 
 "@mapbox/mapbox-gl-draw@1.1.2":
   version "1.1.2"
@@ -138,16 +156,16 @@
   integrity sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==
 
 "@mapbox/mapbox-sdk@^0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-sdk/-/mapbox-sdk-0.13.2.tgz#a759ccecd8252d7703a9209f028603375c5680d2"
-  integrity sha512-VP2+Gyada3G8IJPbiD+9KZMEIxqITyPjVL66FBav2qjFhlHf5LrRCoZ4IbI6Os8DZadSEyxDGVU/doLaohkJRw==
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-sdk/-/mapbox-sdk-0.13.7.tgz#05e1bf287d86868623d748c19865b1fee7222642"
+  integrity sha512-JZjBsAVSBv7lX7gQPOQwftBGHIUcvL/tPKFxAL+SCT7u1n+eRH052XebOTkl28pNm7Du6DpKAs1GvgUnDcFFDQ==
   dependencies:
     "@mapbox/fusspot" "^0.4.0"
     "@mapbox/parse-mapbox-token" "^0.2.0"
     "@mapbox/polyline" "^1.0.0"
     eventemitter3 "^3.1.0"
     form-data "^3.0.0"
-    got "^10.7.0"
+    got "^11.8.5"
     is-plain-obj "^1.1.0"
     xtend "^4.0.1"
 
@@ -161,12 +179,12 @@
 "@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
-  integrity sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=
+  integrity sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==
 
 "@mapbox/polyline@^1.0.0":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/polyline/-/polyline-1.1.1.tgz#ab96e5e6936f4847a4894e14558daf43e40e3bd2"
-  integrity sha512-z9Sl7NYzsEIrAza658H92mc0OvpBjQwjp7Snv4xREKhsCMat7m1IKdWJMjQ5opiPYa0veMf7kCaSd1yx55AhmQ==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/polyline/-/polyline-1.2.0.tgz#11f7481968a83bd9dde36273a50b8037af24a86b"
+  integrity sha512-sIIi9clVZiTmXYqbXpSAoG+ZLsvQn7j9FJLqiNOG85KnXN8tz11MEhuW2M7NDEDIKi4hIMaSI1CKwH8oLuVxPQ==
   dependencies:
     meow "^6.1.1"
 
@@ -178,7 +196,7 @@
 "@mapbox/unitbezier@^0.0.0":
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz#15651bd553a67b8581fb398810c98ad86a34524e"
-  integrity sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=
+  integrity sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==
 
 "@mapbox/vector-tile@^1.3.1":
   version "1.3.1"
@@ -192,12 +210,12 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
-"@sindresorhus/is@^2.0.0":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-2.1.1.tgz#ceff6a28a5b4867c2dd4a1ba513de278ccbe8bb1"
-  integrity sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==
+"@sindresorhus/is@^4.0.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@szmarczak/http-timer@^4.0.0":
+"@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"
   integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
@@ -205,14 +223,14 @@
     defer-to-connect "^2.0.0"
 
 "@tmcw/togeojson@^4.3.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@tmcw/togeojson/-/togeojson-4.5.0.tgz#9b5c7bdd8c5ad3b9c504824d3cdef9b60edbd206"
-  integrity sha512-lNuuhW7nvN1T7xII9eRTi9zuPwYfFl43/1u/Xgi88tedX4ePfwJB5dqc31N7z6sWeR+7EES274ESNrK1gsW53A==
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@tmcw/togeojson/-/togeojson-4.7.0.tgz#071d6d6d01f0aa86299cc98e3cdb102f1119241d"
+  integrity sha512-edAPymgIEIY/jrEmATYe56a46XHvPVm7SXhf29h7jSAUrRhLOIFIlbHPCsic/gGDSvWODTSioRFpXgou47ZLYg==
 
 "@turf/along@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/along/-/along-4.7.3.tgz#a4981f254cc7f0aa3713bee2e755fef3506b8518"
-  integrity sha1-pJgfJUzH8Ko3E77i51X+81BrhRg=
+  integrity sha512-LfP8wVb2xkG1tAI28VvvU8/OO7t5zbJVb5BbWydVhrwpvOBctaG8dIhtiphEPiMp5L4rTIX5jrLsPHle8Z8k2Q==
   dependencies:
     "@turf/bearing" "^4.7.3"
     "@turf/destination" "^4.7.3"
@@ -222,7 +240,7 @@
 "@turf/area@^3.13.0", "@turf/area@^3.7.0":
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/@turf/area/-/area-3.14.0.tgz#f3197ed4e9710d02cd8bbd551b25c476fe47e89b"
-  integrity sha1-8xl+1OlxDQLNi71VGyXEdv5H6Js=
+  integrity sha512-AwXi1+udChyKKZ7MDUUqtBd1fkVxVPQBx/zstZWZ108RkrNCfudHzOD9lEAKvjk67s11JjX/9Mgv1gkza8mdMw==
   dependencies:
     "@mapbox/geojson-area" "^0.2.2"
     "@turf/meta" "^3.14.0"
@@ -230,7 +248,7 @@
 "@turf/area@^4.4.0", "@turf/area@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/area/-/area-4.7.3.tgz#5cc45b5a524e98e1c171e7190709c669ca699305"
-  integrity sha1-XMRbWlJOmOHBcecZBwnGacppkwU=
+  integrity sha512-UnfWEuLeARBPmtkwxSVzZpgavMRdvbUV1BmHIzaN9x53qdENdv2frBJ0n0Qb4njyDMvABDUlMK83n4xDC4lHwQ==
   dependencies:
     "@mapbox/geojson-area" "^0.2.2"
     "@turf/meta" "^4.7.3"
@@ -238,7 +256,7 @@
 "@turf/bbox-clip@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/bbox-clip/-/bbox-clip-4.7.3.tgz#ba689c80a4cc38b2ec539d6de9a831087f450c09"
-  integrity sha1-umicgKTMOLLsU51t6agxCH9FDAk=
+  integrity sha512-XFxZSYvb5U8V/BUyH4wBZM4ZfEJSy0R726DR7sfgzkH497hvcjrMQJsqIOrcYpuIV7mP0wCJ6Q9XWsq3B2MTIQ==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -247,56 +265,56 @@
 "@turf/bbox-polygon@^4.4.0", "@turf/bbox-polygon@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-4.7.3.tgz#358890fd1f1a6cad9a9cb50799e37325fb88017a"
-  integrity sha1-NYiQ/R8abK2anLUHmeNzJfuIAXo=
+  integrity sha512-hJgq4ao67XR+5hLY23f/Eg5Urtnwa5vpBjwLa7lBfpP/FoGvWZE3uiRBECKFH9AMX2AkhMaqueVu2vjU5duZNQ==
   dependencies:
     "@turf/helpers" "^4.7.3"
 
 "@turf/bbox@4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-4.7.1.tgz#c2f05ec2bec10b9a3b4e045400aafab35b2f4cff"
-  integrity sha1-wvBewr7BC5o7TgRUAKr6s1svTP8=
+  integrity sha512-IJcqoRSSCs0XqWDPhnRVDoh/N9fE1Lhfdxz0NjXcXu8zTZnlOokoW50rWybOsWytdMKGv1MdT6la9H/CAW3xYQ==
   dependencies:
     "@turf/meta" "4.7.1"
 
 "@turf/bbox@^3.14.0":
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-3.14.0.tgz#cee5f396dde78aca9cede05e1122db18bc504635"
-  integrity sha1-zuXzlt3nisqc7eBeESLbGLxQRjU=
+  integrity sha512-INE3pLLnPt0J3z9vh18drKU/zBnfA26gQw94AdQDlpgv78mOs1qBMcnymhuxWgtAwLLXVhIPp2/GfiZsueseDA==
   dependencies:
     "@turf/meta" "^3.14.0"
 
 "@turf/bbox@^4.4.0", "@turf/bbox@^4.7.1", "@turf/bbox@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-4.7.3.tgz#e3ad4f10a7e9b41b522880d33083198199059067"
-  integrity sha1-461PEKfptBtSKIDTMIMZgZkFkGc=
+  integrity sha512-78lSzSQuLHq0363sVlmkX9uxBejeWGyZhQBAh7oc1ucnsYsem1m4ynjDXG8/hKP4nG/yUFWPdV9xklezKdvzKw==
   dependencies:
     "@turf/meta" "^4.7.3"
 
 "@turf/bearing@^4.4.0", "@turf/bearing@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-4.7.3.tgz#efd1a8a5c8ca0cdbecbcc02172c41ed216dff8f9"
-  integrity sha1-79GopcjKDNvsvMAhcsQe0hbf+Pk=
+  integrity sha512-VI3QsVFdfiZwZX3V6rDERXsY8BcYq7RuDUi7YoX8CKxXDcwkoFZqjoSCzKUO7wMpXwI8QIN/phBwqZfZZwH2Nw==
   dependencies:
     "@turf/invariant" "^4.7.3"
 
 "@turf/bezier@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/bezier/-/bezier-4.7.3.tgz#34bdd8e96f22726aad1f35683173882cf616be48"
-  integrity sha1-NL3Y6W8icmqtHzVoMXOILPYWvkg=
+  integrity sha512-t7wO3BeYRkMqM0nfweUzvFEs/JXpGdjsMIKPDMP5Rhohd5ZETMlthGels6Fo8KyC7OTm+0PQcnu67WLErjHsIA==
   dependencies:
     "@turf/helpers" "^4.7.3"
 
 "@turf/boolean-clockwise@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/boolean-clockwise/-/boolean-clockwise-4.7.3.tgz#0627916b1c43e06e00ed2c8117b20cfa6fbf7014"
-  integrity sha1-BieRaxxD4G4A7SyBF7IM+m+/cBQ=
+  integrity sha512-MOTTaHq5jFtdg9vDEQ7kr24ycbb8x2F/ERM5n/AQXzqByEv7LihODIW2NZg+qqqJcl3qltah72l71rFCkWOYtg==
   dependencies:
     "@turf/invariant" "^4.7.3"
 
 "@turf/boolean-overlap@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/boolean-overlap/-/boolean-overlap-4.7.3.tgz#8f8a5168d37ace5158cff6f4b0c234dd376c1b48"
-  integrity sha1-j4pRaNN6zlFYz/b0sMI03TdsG0g=
+  integrity sha512-iO4vhx1SwKjMgdppkXzOsksRe8MkjJJs8HwTGWuuoUMW02JrrGZfX7KZ6K+Myg6Tn9xD6LOCw9mOvr2zGc0BAw==
   dependencies:
     "@turf/invariant" "^4.7.3"
     "@turf/line-intersect" "^4.7.3"
@@ -307,14 +325,14 @@
 "@turf/boolean-point-on-line@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/boolean-point-on-line/-/boolean-point-on-line-4.7.3.tgz#68ee97b70bc6255f67cd1e51a45658411bcb9799"
-  integrity sha1-aO6XtwvGJV9nzR5RpFZYQRvLl5k=
+  integrity sha512-xQgPrrzXGq7rK4pCJvvoWxwSBc3b66WTu7rML0U2WBNMIzmkbqFOo+u/dxKgLMzQgSdfOkPI0i1fXPHscr6HJg==
   dependencies:
     "@turf/invariant" "^4.7.3"
 
 "@turf/buffer@^4.4.0":
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/@turf/buffer/-/buffer-4.7.4.tgz#eaf0747051a8c3242db2783d9832421ac2ee3fbb"
-  integrity sha1-6vB0cFGowyQtsng9mDJCGsLuP7s=
+  integrity sha512-yUG+trJa5Xki5RTZkbg0+ce7FJMb34jtzxoSz0n0k7oozeUCsAO8ftaVUiiV/UQy4JlYbs8CsCnHTOitHBNuyA==
   dependencies:
     "@turf/bbox" "^4.7.1"
     "@turf/center" "4.7.1"
@@ -327,7 +345,7 @@
 "@turf/center-of-mass@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/center-of-mass/-/center-of-mass-4.7.3.tgz#67a665c704e334bcff8e2897755fbc2bb327bc9b"
-  integrity sha1-Z6ZlxwTjNLz/jiiXdV+8K7MnvJs=
+  integrity sha512-rpHKJCezYOCSgMnqRJZF8hpBgWZJalTobpqeurCqG+GQwR9OTyAk5wYl1Z1XMtr+75Mgmu2CTZVjl4klwoZADw==
   dependencies:
     "@turf/centroid" "^4.7.3"
     "@turf/convex" "^4.7.3"
@@ -339,7 +357,7 @@
 "@turf/center@4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@turf/center/-/center-4.7.1.tgz#5c66c56144f07c35e26292ca61b4105b1b53a8d2"
-  integrity sha1-XGbFYUTwfDXiYpLKYbQQWxtTqNI=
+  integrity sha512-i4F0tLp0QIz7Lmqvaa8Hu+SVQVX6n7f9dFsdFp8iE3JrYbvbu0w3UYHnrpxx9vUEEAVoPYeu97M7NpMxPgS4kA==
   dependencies:
     "@turf/bbox" "4.7.1"
     "@turf/helpers" "4.7.1"
@@ -347,7 +365,7 @@
 "@turf/center@^4.4.0", "@turf/center@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/center/-/center-4.7.3.tgz#744e5c652a7b1bbd0e1ee3f05e30dde43e2a35a4"
-  integrity sha1-dE5cZSp7G70OHuPwXjDd5D4qNaQ=
+  integrity sha512-V17vfzG48GhCRgTVflODxiezGISUAWcmE/HzsTEp6B/fU0ZqhNlEXQTYr0qD46g+gn0BPQu4YNND9azfiBXBZQ==
   dependencies:
     "@turf/bbox" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -355,7 +373,7 @@
 "@turf/centroid@^4.4.0", "@turf/centroid@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/centroid/-/centroid-4.7.3.tgz#205a7675719b0c8e175bb7565c5d6fe267d88175"
-  integrity sha1-IFp2dXGbDI4XW7dWXF1v4mfYgXU=
+  integrity sha512-TuCq6tZOI+jfwuVtX/2AMycVkM2ghYEwan9SszVlOA4KZxSZVopk8IiSqu3B9Tsf15E0UGvVc/awIdUzLJhP5w==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/meta" "^4.7.3"
@@ -363,7 +381,7 @@
 "@turf/circle@^4.4.0", "@turf/circle@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/circle/-/circle-4.7.3.tgz#e8f996ff87b0ca8e3e6b74b60f6ab5daf9086713"
-  integrity sha1-6PmW/4ewyo4+a3S2D2q12vkIZxM=
+  integrity sha512-6LpuccDa2zPm+/BnDrm4w4/G82O1F9YXAXoYDAMOWXZPNeN9zFSsUEdhdpqNcWuOYd1/tipTs9iXmNR30/H4KA==
   dependencies:
     "@turf/destination" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -371,7 +389,7 @@
 "@turf/clean-coords@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/clean-coords/-/clean-coords-4.7.3.tgz#bc3e6523afe42dc88dba5da1a713072a5cd6da0f"
-  integrity sha1-vD5lI6/kLciNul2hpxMHKlzW2g8=
+  integrity sha512-si30bdVGdsMaNGMcsKmmBO8DBM9Nd9BIoR8Udz62W/Ze0MbXkZmb7S7oyXQ28EVbnIbE7sKlkTySIdizkD3K5Q==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -379,12 +397,12 @@
 "@turf/clone@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-4.7.3.tgz#6e507be4d648fa62c5e6ce926f7e83a22f53ae69"
-  integrity sha1-blB75NZI+mLF5s6Sb36Doi9Trmk=
+  integrity sha512-0iT6+CfOF82KTsJ+Y1AkXkVDANkhWUuA4UjRQina9zUtiTXq+Y1teEWt8PBMCwx+Fgh+zw8aInsa6tLCGGaJMg==
 
 "@turf/collect@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/collect/-/collect-4.7.3.tgz#c92b5921f8822983cbceaca3e1bd5bee73aae9ff"
-  integrity sha1-yStZIfiCKYPLzqyj4b1b7nOq6f8=
+  integrity sha512-7P+BybLopItPGcuCwXrwJmqRKOdhQ43MyMLaXnjmbHKFx3d01Y2HIhLBrujmSaEdNcmLpi7sGH6G1MJNimdzSg==
   dependencies:
     "@turf/bbox" "^4.7.3"
     "@turf/inside" "^4.7.3"
@@ -393,14 +411,14 @@
 "@turf/combine@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/combine/-/combine-4.7.3.tgz#95ad31253e13c86fc613cb4ff7683adb50c32e06"
-  integrity sha1-la0xJT4TyG/GE8tP92g621DDLgY=
+  integrity sha512-80HWtNEC6uXO2T7c4Hz3LHcO0rLTxz8UbKVOlKnAvJLX/F0bVzhyqYdmgagiWz9sazZgDhDEc87Dk3WHbS2l8g==
   dependencies:
     "@turf/meta" "^4.7.3"
 
 "@turf/concave@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/concave/-/concave-4.7.3.tgz#0f80a12a142bc407ef8632c41820852003404d9e"
-  integrity sha1-D4ChKhQrxAfvhjLEGCCFIANATZ4=
+  integrity sha512-mhwn8FJHGcYM5PuhYQHQL6KYD01ekN70jpCjDbi2/wE1Bmda8TGlUmIuq8I9RvF+S+5e99J2k0uNDU5wb0l63Q==
   dependencies:
     "@turf/distance" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -411,7 +429,7 @@
 "@turf/convex@^4.4.0", "@turf/convex@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/convex/-/convex-4.7.3.tgz#1e06093d8453fa59c17d6755cb5ec96f4687363a"
-  integrity sha1-HgYJPYRT+lnBfWdVy17Jb0aHNjo=
+  integrity sha512-zNgwxM1CWbyMmIHDJ/gCnEXBLoAnU8LurtHAwVAdeFI3lYBnnNcpSFuPbBv8Y5d3nN1/ZG7zfs3H2vIonRHXww==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/meta" "^4.7.3"
@@ -420,7 +438,7 @@
 "@turf/destination@^4.4.0", "@turf/destination@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/destination/-/destination-4.7.3.tgz#f1ea3bb3705cf52fed135a7917d49336e47b8d2e"
-  integrity sha1-8eo7s3Bc9S/tE1p5F9STNuR7jS4=
+  integrity sha512-nqihJgzsXXyoyLMgmxifefePAPKpaWR1haXvK3VhXCdv1svL4i2eD79oTz9+YQJSkJc1I83MZOOXVFyad7B/Nw==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -428,7 +446,7 @@
 "@turf/difference@^4.4.0":
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/@turf/difference/-/difference-4.7.4.tgz#9286190d7dd151dda57bae39fe92e4b88bc3361a"
-  integrity sha1-koYZDX3RUd2le645/pLkuIvDNho=
+  integrity sha512-/PC9VNJ/zjDbM9wWGWhNByoseMP1qDevGaXn4H55s/6jt+3Kbljb66HIxR7NysjZrlkePVI40ZES38qscQzz1w==
   dependencies:
     "@turf/area" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -439,7 +457,7 @@
 "@turf/dissolve@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/dissolve/-/dissolve-4.7.3.tgz#36b70e68cf41d4bc3b4b86b952d402088f1a4170"
-  integrity sha1-NrcOaM9B1Lw7S4a5UtQCCI8aQXA=
+  integrity sha512-zf7KIFJYUhKwgpbhWa7hT6xbBc9SqmE6wraXlQZgntC8JgpzYSxe8eUt5nt16R/qK4qxkYC1RJUgSkeYG9p2Tw==
   dependencies:
     "@turf/bbox" "^4.7.3"
     "@turf/boolean-overlap" "^4.7.3"
@@ -451,7 +469,7 @@
 "@turf/distance@^4.4.0", "@turf/distance@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-4.7.3.tgz#b5ab48a09a642706d65c39b919433d5d2cc571b1"
-  integrity sha1-tatIoJpkJwbWXDm5GUM9XSzFcbE=
+  integrity sha512-nluvFy7qjZFq4B6E+KAlKdwdg9fbgJMIe/5O7jveg56gcXZ5Bvgx3lFUxAY016+l907OeX9lIZCNr/Y96FMyEA==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -459,7 +477,7 @@
 "@turf/envelope@^4.3.0", "@turf/envelope@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/envelope/-/envelope-4.7.3.tgz#22642a6935e515866be075c88f03483a20c02096"
-  integrity sha1-ImQqaTXlFYZr4HXIjwNIOiDAIJY=
+  integrity sha512-xqWJSW4Eo2teEfJujl36vIVGTt5A/S1+yK+cmbBTYuGTOpwUIlrsolf3RYU3AXB1VWlptrT3DNZVBLd8o17DPA==
   dependencies:
     "@turf/bbox" "^4.7.3"
     "@turf/bbox-polygon" "^4.7.3"
@@ -467,7 +485,7 @@
 "@turf/explode@^3.7.0":
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/@turf/explode/-/explode-3.14.0.tgz#f2cc1e46a39700d5602466ccd50f59a52341b92c"
-  integrity sha1-8sweRqOXANVgJGbM1Q9ZpSNBuSw=
+  integrity sha512-S7QvYBMAua4kmaelUF2ckfq/NGARq0B8RYhmvEeyq8SKA8ExJMNqjYbP6v7zDC7yRiK8tn89aNILw97xIc3bCw==
   dependencies:
     "@turf/helpers" "^3.13.0"
     "@turf/meta" "^3.14.0"
@@ -475,7 +493,7 @@
 "@turf/explode@^4.4.0", "@turf/explode@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/explode/-/explode-4.7.3.tgz#f7e2efb25aea03410cce1e9816584ba94fc91846"
-  integrity sha1-9+LvslrqA0EMzh6YFlhLqU/JGEY=
+  integrity sha512-7dTbk4MUoybTdL0kLa3zGq0yWIeUK8yQMO2mA7wwZvNj7NVAG70F4Q5+UH3fTIdheh5dvlgGFsJglNpcWNC+mA==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/meta" "^4.7.3"
@@ -483,7 +501,7 @@
 "@turf/flatten@^4.4.0", "@turf/flatten@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/flatten/-/flatten-4.7.3.tgz#7ea409fbc6fb4ee2f142834b4186d0f69da8350a"
-  integrity sha1-fqQJ+8b7TuLxQoNLQYbQ9p2oNQo=
+  integrity sha512-fBMei5B41U/yKY/+yCiSqt9buqTV5jZCjU/D2lyOfTiu6TYvNt/oaK53GUE7IJliAAjiaXjXUP+RGsIvDadCMA==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/meta" "^4.7.3"
@@ -491,41 +509,41 @@
 "@turf/flip@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/flip/-/flip-4.7.3.tgz#9d7c956facf6512111f104d43e167cb64f7cdc16"
-  integrity sha1-nXyVb6z2USER8QTUPhZ8tk983BY=
+  integrity sha512-CR8PhVhRMHcgTDkyTu9ems/XCA5UxpeDVgaPUFXjTNc1nF3BTxnfz9zHKFKBmIGrBcTOuNyLaGMmnMxbE9q+YA==
   dependencies:
     "@turf/meta" "^4.7.3"
 
 "@turf/great-circle@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/great-circle/-/great-circle-4.7.3.tgz#813255740abcf0cf2db9bfef2749b11604c06cd1"
-  integrity sha1-gTJVdAq88M8tub/vJ0mxFgTAbNE=
+  integrity sha512-y1aX0AcCjvS4IKEWPV/cKz22AjAASNHoOAYpCX8hQIudK2FCLpA35qucLYnAhjMPG5FiF8X9gKsl5VZseF9ZFA==
   dependencies:
     "@turf/invariant" "^4.7.3"
 
 "@turf/helpers@4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-4.7.1.tgz#12cecbfe22b16386338537dae3e3da83de2f3fac"
-  integrity sha1-Es7L/iKxY4YzhTfa4+Pag94vP6w=
+  integrity sha512-C1TGudzOyot+KiQFq20kaQJSPJZugRcvcYfLSNdwJYJw1glAlHY//2Ij542LXLK6/jzXTVVhdSNcPBvbw4sWAQ==
 
 "@turf/helpers@5.x", "@turf/helpers@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"
-  integrity sha1-FTQFInq5M9AEpbuWQantmZ/L4M8=
+  integrity sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw==
 
 "@turf/helpers@^3.13.0", "@turf/helpers@^3.6.3":
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-3.13.0.tgz#d06078a1464cf56cdb7ea624ea1e13a71b88b806"
-  integrity sha1-0GB4oUZM9WzbfqYk6h4TpxuIuAY=
+  integrity sha512-iDtLM9XHGhQUN0hxLGAKJTmaNnM7ffxdAVVrIRQUREatb78ls9seqwnpM2JSFc8ZgFEapwRhHK8FRBH6zIbHkA==
 
 "@turf/helpers@^4.1.0", "@turf/helpers@^4.3.0", "@turf/helpers@^4.4.0", "@turf/helpers@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-4.7.3.tgz#bc312ac43cab3c532a483151c4c382c5649429e9"
-  integrity sha1-vDEqxDyrPFMqSDFRxMOCxWSUKek=
+  integrity sha512-hk5ANVazb80zK6tjJYAG76oCRTWMQo6SAFu5E1dVnlb2kT3FHLoPcOB9P11duwDafMwywz24KZ+FUorB5e728w==
 
 "@turf/hex-grid@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/hex-grid/-/hex-grid-4.7.3.tgz#6eacc4d153cf430777deae7a48698cfb27ae7ec6"
-  integrity sha1-bqzE0VPPQwd33q56SGmM+yeufsY=
+  integrity sha512-o10BzbwszM0MFtdl/9ClCxFZagHuoG6832DAukfO3l6HjBZtb16F8ojVvgdxXzlLE0qztykPi88GJJwUoAaJkQ==
   dependencies:
     "@turf/distance" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -533,7 +551,7 @@
 "@turf/idw@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/idw/-/idw-4.7.3.tgz#b8a9b2213265e00609ffbbf86a05af17523a3b25"
-  integrity sha1-uKmyITJl4AYJ/7v4agWvF1I6OyU=
+  integrity sha512-+Z2wEf/agYdYNdte7IefkWuCoOnHP7EAkzCjFrm6UxBrycuh7Xd0S3SBu+5rWc1CNdLaWstOu7xeVyeskqw2/w==
   dependencies:
     "@turf/bbox" "^4.7.3"
     "@turf/centroid" "^4.7.3"
@@ -543,21 +561,21 @@
 "@turf/inside@^3.14.0", "@turf/inside@^3.7.0":
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/@turf/inside/-/inside-3.14.0.tgz#d6b6af55882cbdb8f9a558dca98689c67bd3c590"
-  integrity sha1-1ravVYgsvbj5pVjcqYaJxnvTxZA=
+  integrity sha512-zIm5T08WnHqJs2gt7zqNCeA2J1vK1+r8oRtrqkeMpBv4cUJ8xBo8cyRU1MzTdIgkVXlQaGDdlNCF9ZIQYicQ+A==
   dependencies:
     "@turf/invariant" "^3.13.0"
 
 "@turf/inside@^4.3.0", "@turf/inside@^4.4.0", "@turf/inside@^4.5.2", "@turf/inside@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/inside/-/inside-4.7.3.tgz#e4a84969f2886891b343b11b83fda3095fba542c"
-  integrity sha1-5KhJafKIaJGzQ7Ebg/2jCV+6VCw=
+  integrity sha512-V/gMvWxoOCMNEz1KUcFVWDS78jvcNtVxNAf2oc3jz8NYs+DUZymkKjHiLkM9NPQ8fjXwsAsFq12DYgTp+HnDig==
   dependencies:
     "@turf/invariant" "^4.7.3"
 
 "@turf/intersect@^4.4.0":
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/@turf/intersect/-/intersect-4.7.4.tgz#d95d5d69fbf132f834eb772251a1da2aae3f33a3"
-  integrity sha1-2V1dafvxMvg063ciUaHaKq4/M6M=
+  integrity sha512-QSJjkfaBrvOehz1j9YuqDKIFUpK7Us6+GGrFdwLaeFpv2acdTRGX1V2b9mG7zQlFJrYbJNUelMTthtw/MOULjQ==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/truncate" "^4.7.3"
@@ -566,24 +584,24 @@
 "@turf/invariant@5.x":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-5.2.0.tgz#f0150ff7290b38577b73d088b7932c1ee0aa90a7"
-  integrity sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=
+  integrity sha512-28RCBGvCYsajVkw2EydpzLdcYyhSA77LovuOvgCJplJWaNVyJYH6BOR3HR9w50MEkPqb/Vc/jdo6I6ermlRtQA==
   dependencies:
     "@turf/helpers" "^5.1.5"
 
 "@turf/invariant@^3.13.0":
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-3.13.0.tgz#89243308cd563206e81e5c6162e0d22f61822f90"
-  integrity sha1-iSQzCM1WMgboHlxhYuDSL2GCL5A=
+  integrity sha512-tqqatJteAlV4CPdAbAAo8DlBFJzlu5cI747/mO8Rfpd70vDvcFzm65RIp/fxvdEP5sSfdc9qsQS4DU2z0bURIA==
 
 "@turf/invariant@^4.1.0", "@turf/invariant@^4.3.0", "@turf/invariant@^4.4.0", "@turf/invariant@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-4.7.3.tgz#538f367d23c113fc849d70c9a524b8563874601d"
-  integrity sha1-U482fSPBE/yEnXDJpSS4Vjh0YB0=
+  integrity sha512-MtlIn9aPC4gZsflLEnfBl/o/SJjZU/yuvj+fo9qRXUOI8wBiKaUcZIT4x1jdLW0NGvU7wMPWJSFJanLCQ9eU1w==
 
 "@turf/isobands@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/isobands/-/isobands-4.7.3.tgz#482efede3ccb428c5529527090fcf8b74791af14"
-  integrity sha1-SC7+3jzLQoxVKVJwkPz4t0eRrxQ=
+  integrity sha512-/pmB3hr3UvCNw8sop5vg9OR3BxnxYUb6iH9TT5mdgq0+gFolnef7Ar0g5faiLP2pAXsBrNY8v5J2MEESXpqEZA==
   dependencies:
     "@turf/area" "^3.7.0"
     "@turf/bbox" "^3.14.0"
@@ -597,7 +615,7 @@
 "@turf/isolines@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/isolines/-/isolines-4.7.3.tgz#306c5b5c7df24632776574725177ef73e3342bb5"
-  integrity sha1-MGxbXH3yRjJ3ZXRyUXfvc+M0K7U=
+  integrity sha512-sMu78BbHZBKQXDaxc1T40WwCenDD7CKwowaTPloImKPB0i20flqF5B3DPxznGC/dbtqzVT5RGa2xUyro8AOkXw==
   dependencies:
     "@turf/bbox" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -609,14 +627,14 @@
 "@turf/kinks@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/kinks/-/kinks-4.7.3.tgz#64e1851f8dd16ed212eb2b27bfd43802fe403565"
-  integrity sha1-ZOGFH43RbtIS6ysnv9Q4Av5ANWU=
+  integrity sha512-YyU1qOGZGAPCo4JW1JdLfFuU8nHQ2nMItJE0rBp2uvoljkVUfUV4gH7EbTQR9sJEYaHv3pY4Ehope4IPQ3u67w==
   dependencies:
     "@turf/helpers" "^4.7.3"
 
 "@turf/line-arc@^4.4.0", "@turf/line-arc@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/line-arc/-/line-arc-4.7.3.tgz#32d6c2331bf63bcacf63c17fc619baa729fdce3f"
-  integrity sha1-MtbCMxv2O8rPY8F/xhm6pyn9zj8=
+  integrity sha512-4DYTPoH/v8v2Ma9IXipoAfCbWiSwPy0mA8TNVYiGuD26I8hbVxO8j3CWdT+FQtNOq/9Iwxfj/xYUzC1NsCSOhA==
   dependencies:
     "@turf/circle" "^4.7.3"
     "@turf/destination" "^4.7.3"
@@ -625,7 +643,7 @@
 "@turf/line-chunk@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/line-chunk/-/line-chunk-4.7.3.tgz#1d914f350321da07756c0125fb5112eb282a78af"
-  integrity sha1-HZFPNQMh2gd1bAEl+1ES6ygqeK8=
+  integrity sha512-WZDK6wt//PpumQ7VMoKcrdhDerx51/B+qtbgDwLwVMrx+d5RhXiONyghL+mnkdtq6cRzUoXkNgaB3kqk3L0Xow==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/line-distance" "^4.7.3"
@@ -635,7 +653,7 @@
 "@turf/line-distance@^4.4.0", "@turf/line-distance@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/line-distance/-/line-distance-4.7.3.tgz#00a33000e088ee5e3a8d92b7b96bb332af373006"
-  integrity sha1-AKMwAOCI7l46jZK3uWuzMq83MAY=
+  integrity sha512-U6sFReqpMJq/LhOoDna4w1Vs2gliJUhFa1g94WrZrVz7l4IHldy7Q0Va0CyQ00qN5n3f09/vf4F+q2+ThHbL4g==
   dependencies:
     "@turf/distance" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -644,7 +662,7 @@
 "@turf/line-intersect@^4.4.0", "@turf/line-intersect@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/line-intersect/-/line-intersect-4.7.3.tgz#072b3738637f7a0454aac708f995a3a29764b056"
-  integrity sha1-Bys3OGN/egRUqscI+ZWjopdksFY=
+  integrity sha512-P4ahMpPq9mfqJGNdFYS45848708jhW8PM2w1qdbwKrTn5WiT4L3+OHzSQoQAApQ/f5S4Ge4TncfsldGN4HYZrg==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -655,7 +673,7 @@
 "@turf/line-offset@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/line-offset/-/line-offset-4.7.3.tgz#a3e24d1c1d990cbfa32b9d9f3cd16446a7ec08d5"
-  integrity sha1-o+JNHB2ZDL+jK52fPNFkRqfsCNU=
+  integrity sha512-A+wbdRMsuNYmLkRqQMKyTzPGnRTU5mdeuOdxXp3oq1QkFHKVVfjjQeFONWC0oYB9G2PCuL+4U4mWyNV90f/kvQ==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -664,7 +682,7 @@
 "@turf/line-overlap@^4.4.0", "@turf/line-overlap@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/line-overlap/-/line-overlap-4.7.3.tgz#5be57ad366f629937e208f311b61efee3995248b"
-  integrity sha1-W+V602b2KZN+II8xG2Hv7jmVJIs=
+  integrity sha512-3kp+3PurY9SdZl/NGDYA1l2I9DDoYljqDFygyWjGf6hKr5fHVvNX+Op84W8gKVpUM1gMS6RaPjaI8xzY3MeXLg==
   dependencies:
     "@turf/boolean-point-on-line" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -678,7 +696,7 @@
 "@turf/line-segment@^4.4.0", "@turf/line-segment@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/line-segment/-/line-segment-4.7.3.tgz#771f71fa653d8e6bbc5a8d892283163e94b34d7a"
-  integrity sha1-dx9x+mU9jmu8Wo2JIoMWPpSzTXo=
+  integrity sha512-zPbm5nugKpGfpfMhmf2C+4WB62F2E2IsWKPnz4gX+t9itWV+EqNdUPi74zArkScy4m6HRsPnIzohmz++6mf/oQ==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -687,7 +705,7 @@
 "@turf/line-slice-along@^4.4.0", "@turf/line-slice-along@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/line-slice-along/-/line-slice-along-4.7.3.tgz#df051d10cbbb29851ee4b7d7e190124b7e0d62cb"
-  integrity sha1-3wUdEMu7KYUe5LfX4ZASS34NYss=
+  integrity sha512-t71zAb3ZldhewfDCXawyOMqB+8nhC3hkID/o5AAx8d2ub987EJExO+wfT3K+oV9yc+87SDEKVRJO2vsio/hWGg==
   dependencies:
     "@turf/bearing" "^4.7.3"
     "@turf/destination" "^4.7.3"
@@ -697,7 +715,7 @@
 "@turf/line-slice@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/line-slice/-/line-slice-4.7.3.tgz#fa546d8c717f772ea7d6afc9964965aa45e18eef"
-  integrity sha1-+lRtjHF/dy6n1q/JlkllqkXhju8=
+  integrity sha512-UW/jw6Kd4ARwjQcob0suOEyrhFN7zFgVfKn7UtOmzbKviXTFqRUp8vduIGyyRh7FgFHIL9OP0g2qUsCUCVqVEw==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/point-on-line" "^4.7.3"
@@ -705,7 +723,7 @@
 "@turf/line-split@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/line-split/-/line-split-4.7.3.tgz#22d81162da37861b7d22859073adef22f8af53db"
-  integrity sha1-ItgRYto3hht9IoWQc63vIvivU9s=
+  integrity sha512-U3ICYQsjipdRTfr36IVnlKVohCuHAMOrW6B3n6Ab+qY/IvObFvxi0ngI9ddAk5hD5tMtJ5ysZ96aenKThLmS+g==
   dependencies:
     "@turf/flatten" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -720,7 +738,7 @@
 "@turf/linestring-to-polygon@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/linestring-to-polygon/-/linestring-to-polygon-4.7.3.tgz#f45fef8c544d8b288f5ba58c2bae349a18fb597f"
-  integrity sha1-9F/vjFRNiyiPW6WMK640mhj7WX8=
+  integrity sha512-RIvf9FOu7rUX19UsoCItamYDkO9k+sk8PrShfMF6ph8ecyT0qjX6Ec5Zoe0TTMuNNKfAbzdO1NEWgVU8HcopUQ==
   dependencies:
     "@turf/bbox" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -729,7 +747,7 @@
 "@turf/mask@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/mask/-/mask-4.7.3.tgz#53d0b4c8114d0be9f8d496ddc048ee17ad639de3"
-  integrity sha1-U9C0yBFNC+n41JbdwEjuF61jneM=
+  integrity sha512-fIzGdBW8JCHLadjd8GGwd+CDlBaEAje1f4rFwyixPdJ7i6L/adNdxQjLT70nG1q9uinl55XSG40oGglzdQlzPg==
   dependencies:
     "@turf/bbox" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -740,29 +758,29 @@
 "@turf/meta@4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-4.7.1.tgz#53a55281ae08a5fa2f414d9ba50a951d38e86ab5"
-  integrity sha1-U6VSga4IpfovQU2bpQqVHTjoarU=
+  integrity sha512-S/+ixW2FQFDZLNWyrnlfYtSQZUZO3DhAaFw0nxd1XGMQ2q2z2mnscTncF7tRWW1OIVhkjXJwb80VADzq+EAIDg==
 
 "@turf/meta@5.x":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-5.2.0.tgz#3b1ad485ee0c3b0b1775132a32c384d53e4ba53d"
-  integrity sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=
+  integrity sha512-ZjQ3Ii62X9FjnK4hhdsbT+64AYRpaI8XMBMcyftEOGSmPMUVnkbvuv3C9geuElAXfQU7Zk1oWGOcrGOD9zr78Q==
   dependencies:
     "@turf/helpers" "^5.1.5"
 
 "@turf/meta@^3.14.0", "@turf/meta@^3.7.5":
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-3.14.0.tgz#8d3050c1a0f44bf406a633b6bd28c510f7bcee27"
-  integrity sha1-jTBQwaD0S/QGpjO2vSjFEPe87ic=
+  integrity sha512-OtXqLQuR9hlQ/HkAF/OdzRea7E0eZK1ay8y8CBXkoO2R6v34CsDrWYLMSo0ZzMsaQDpKo76NPP2GGo+PyG1cSg==
 
 "@turf/meta@^4.1.0", "@turf/meta@^4.3.0", "@turf/meta@^4.4.0", "@turf/meta@^4.6.0", "@turf/meta@^4.7.3":
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-4.7.4.tgz#6de2f1e9890b8f64b669e4b47c09b20893063977"
-  integrity sha1-beLx6YkLj2S2aeS0fAmyCJMGOXc=
+  integrity sha512-cvwz4EI9BjrgRHxmJ3Z3HKxq6k/fj/V95kwNZ8uWNLncCvrb7x1jUBDkQUo1tShnYdZ8eBgA+a2bvJmAM+MJ0A==
 
 "@turf/midpoint@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/midpoint/-/midpoint-4.7.3.tgz#9b12cd5c7c5d15fce3d6b00b2138982d497c1426"
-  integrity sha1-mxLNXHxdFfzj1rALITiYLUl8FCY=
+  integrity sha512-549hf0146R0LWSfY1YXuYNw3p0P9UttxXz3Xho+ECkcHkYToGiM3xfLa8USCle8/Ko1VN+IXaQ5jiVrPI+2seQ==
   dependencies:
     "@turf/bearing" "^4.7.3"
     "@turf/destination" "^4.7.3"
@@ -771,21 +789,21 @@
 "@turf/nearest@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/nearest/-/nearest-4.7.3.tgz#fce14ae01985fec6b3438a1f9c0a474cf6e02ae2"
-  integrity sha1-/OFK4BmF/sazQ4ofnApHTPbgKuI=
+  integrity sha512-HJlzoWmhNeTSZk/lQaSJKcWxWu0BmUlW4I7xEVSIYbP2WbR/cL2yIM3JbCZAaELs35l9T4d8Z0r5+QilFR0Qew==
   dependencies:
     "@turf/distance" "^4.7.3"
 
 "@turf/planepoint@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/planepoint/-/planepoint-4.7.3.tgz#d055dcc21eaf1c6ed99bf9987157f73ba0a1da7f"
-  integrity sha1-0FXcwh6vHG7Zm/mYcVf3O6Ch2n8=
+  integrity sha512-9swirMuUeU+bEGgQZJFwOVqpEZBylX1+8CDxhHgBB5jxZtMjY/9FZKlgPtw9fkAaKievDvddlwFtang9NH7mjA==
   dependencies:
     "@turf/invariant" "^4.7.3"
 
 "@turf/point-grid@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/point-grid/-/point-grid-4.7.3.tgz#33bc3c921b521897e282c0b882e106508052ed7d"
-  integrity sha1-M7w8khtSGJfigsC4guEGUIBS7X0=
+  integrity sha512-2b90Zr3Ra5XYZ8jPLasPbMsaR1h0iKJRcyLI1c4vyxo+vMrDidaBwFR16xcfWMZQLV7TSKWVueSaS1rzHb1z2A==
   dependencies:
     "@turf/bbox" "^4.7.3"
     "@turf/distance" "^4.7.3"
@@ -796,7 +814,7 @@
 "@turf/point-on-line@^4.4.0", "@turf/point-on-line@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/point-on-line/-/point-on-line-4.7.3.tgz#944a1e7b2c4375f488e83ce55eab35454e9ab7b7"
-  integrity sha1-lEoeeyxDdfSI6DzlXqs1RU6at7c=
+  integrity sha512-OUpbBpySsgsO6LAjFi2vEjV//6zD2nSSMZBp1lW/I6Wt1P9N9hHgCIqIL1/n5se7yMQc/U3+43YbT5ueSbExpw==
   dependencies:
     "@turf/bearing" "^4.7.3"
     "@turf/destination" "^4.7.3"
@@ -809,7 +827,7 @@
 "@turf/point-on-surface@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/point-on-surface/-/point-on-surface-4.7.3.tgz#25ec360bec7f9fa612d705808cf0310d72c2be5f"
-  integrity sha1-Jew2C+x/n6YS1wWAjPAxDXLCvl8=
+  integrity sha512-a+9zaU/xDLXm7gqe9oR1JJLLMdvgZoQjQj9zTdNjbI4378xaxmlwrHvOtRnFtXDj+43NLQFus9KmcEdWtreXWA==
   dependencies:
     "@turf/center" "^4.7.3"
     "@turf/distance" "^4.7.3"
@@ -820,7 +838,7 @@
 "@turf/polygon-tangents@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/polygon-tangents/-/polygon-tangents-4.7.3.tgz#9ddfac9b9b3840f4c43be65d69321f1cd47a7b24"
-  integrity sha1-nd+sm5s4QPTEO+ZdaTIfHNR6eyQ=
+  integrity sha512-3zvc/mwl+z2z/fOQY2Gb6oZU0hM8k6gm+Dg0lMwXBzACDcJELYIznecwMeWJW1gW98E6h0dQJWAcEZtlHlAR0g==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -828,7 +846,7 @@
 "@turf/polygon-to-linestring@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/polygon-to-linestring/-/polygon-to-linestring-4.7.3.tgz#ab867c0d39581bc411c49e0263fd18b4674171a1"
-  integrity sha1-q4Z8DTlYG8QRxJ4CY/0YtGdBcaE=
+  integrity sha512-hMYYBk14jvEeQOroyvcul/FFRxZpShj4EIckEm2Ub2YFaMFY5BCgAYlq6+HzCzVf9pqV4NAB3ziF+BJsNuK8Hw==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -836,14 +854,14 @@
 "@turf/polygonize@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/polygonize/-/polygonize-4.7.3.tgz#0f88ddacd71c6f2c0b96c69ce67555437ea195df"
-  integrity sha1-D4jdrNccbywLlsac5nVVQ36hld8=
+  integrity sha512-0d5cTIcRZ8cN1O+TAa0tzuZp8VWcPpMuPYH0FXOc8b9K+bUghmNbrvCKTeVGTkBIeZqXyUerbmjWAtX/mRf4dQ==
   dependencies:
     polygonize "1.0.1"
 
 "@turf/projection@^4.7.1":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/projection/-/projection-4.7.3.tgz#c3e45745d89371ee720e43add56f08850e90694a"
-  integrity sha1-w+RXRdiTce5yDkOt1W8IhQ6QaUo=
+  integrity sha512-f2s0JOmOLUoydLrighEZLjQ9bTIWTEjZvSymlj9Q7xp0uXqtOesT5D0DW1EIdC0L6ZdqzJhUB0BqGgePSgOIFQ==
   dependencies:
     "@turf/clone" "^4.7.3"
     "@turf/meta" "^4.7.3"
@@ -851,14 +869,14 @@
 "@turf/random@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/random/-/random-4.7.3.tgz#0a8a3b84a1f15b8916d4dce43566beb2e2bda522"
-  integrity sha1-Coo7hKHxW4kW1NzkNWa+suK9pSI=
+  integrity sha512-N7317cwwr5DAgCvE4+YwNg/UtKG1rok20I28NSspnRcj2NEDVJGFzf/q+f5QqzZjinvrNVRcr54K/1siJmtsYg==
   dependencies:
     geojson-random "^0.2.2"
 
 "@turf/rewind@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/rewind/-/rewind-4.7.3.tgz#69899fc3ec53d611b55051fa00c51508d903c5bf"
-  integrity sha1-aYmfw+xT1hG1UFH6AMUVCNkDxb8=
+  integrity sha512-w5y2BN542T0zIUYnyTMVat4uHM26FzQbN90SdWEFLNF8Y3QwS3USmp1p1Yhr+H8GgoEnDlGRr6gnsoPxYYRbnw==
   dependencies:
     "@turf/boolean-clockwise" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -868,7 +886,7 @@
 "@turf/rhumb-bearing@^4.4.0", "@turf/rhumb-bearing@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/rhumb-bearing/-/rhumb-bearing-4.7.3.tgz#db1821b62706fb403adbf9413cc5e56b79006146"
-  integrity sha1-2xghticG+0A62/lBPMXla3kAYUY=
+  integrity sha512-v21ua0t0GbdZ77qtXJMI87igkEqUCnUKSCA4ZYrPFzIvECmAcf01zOgDCyOT2wHkf5aOzj1I25K9VfhbLq8FDw==
   dependencies:
     "@turf/invariant" "^4.7.3"
     geodesy "1.1.2"
@@ -876,7 +894,7 @@
 "@turf/rhumb-destination@^4.4.0", "@turf/rhumb-destination@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/rhumb-destination/-/rhumb-destination-4.7.3.tgz#1b74188c282a790d302e7d8447a077a5e1242aee"
-  integrity sha1-G3QYjCgqeQ0wLn2ER6B3peEkKu4=
+  integrity sha512-Hk8MBjZMf1qgmFWlmsPKItDWyXsxT/uesCapY7BofCM7b3kvmRuNaw4yE0YIfzOlOZfHfVHpBPpBOr/loeO0BA==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -885,7 +903,7 @@
 "@turf/rhumb-distance@^4.4.0", "@turf/rhumb-distance@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/rhumb-distance/-/rhumb-distance-4.7.3.tgz#30eebc6b785502bd8e08548069712c9709ed22d4"
-  integrity sha1-MO68a3hVAr2OCFSAaXEslwntItQ=
+  integrity sha512-1ohJzJU8lz/QpxvwwLPta0zu6HMrWcCqgvrEy4LTf0IFfAHR4QJOKo9WBCG29XYB5Vks4WueyJi9wES/d9QcdA==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -894,14 +912,14 @@
 "@turf/sample@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/sample/-/sample-4.7.3.tgz#d030620c5e382076b7dcbe55ef83c4aa5eef24ab"
-  integrity sha1-0DBiDF44IHa33L5V74PEql7vJKs=
+  integrity sha512-gs7Qf9YRS7TTP9JETsYHOP+uLzjbrl+yAlskRdr7HEnaMis2aLiHsPhV74L4B+OQkQONpzR1C9qTPFxdQfmHGg==
   dependencies:
     "@turf/helpers" "^4.7.3"
 
 "@turf/sector@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/sector/-/sector-4.7.3.tgz#6fee9fad8067fd94cd74c844fe63444b6cdc5f1c"
-  integrity sha1-b+6frYBn/ZTNdMhE/mNES2zcXxw=
+  integrity sha512-DA2N5Ex7MaCcfFIoITkImHhCE8FZZsBVi+iKd/CzbAfLl5HdF+F0dTD9b9U+14K44+5z4a0mYlPa3IPdy/0ISw==
   dependencies:
     "@turf/circle" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -912,7 +930,7 @@
 "@turf/simplify@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/simplify/-/simplify-4.7.3.tgz#2efd5b468dcdf4751d05ee63b7a3ea46450875f3"
-  integrity sha1-Lv1bRo3N9HUdBe5jt6PqRkUIdfM=
+  integrity sha512-aa08e1AFXuL0zt+f1BxJ49SuuHPYT4hY1YxJIE8odjEOnYO82Mtgco6KkijrI2xrYAckr6QFqLYi7CWaH8SWmw==
   dependencies:
     "@turf/clean-coords" "^4.7.3"
     "@turf/clone" "^4.7.3"
@@ -923,7 +941,7 @@
 "@turf/square-grid@^4.4.0", "@turf/square-grid@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/square-grid/-/square-grid-4.7.3.tgz#b3e896b132a34fcc77ed3907efd9a4444db62259"
-  integrity sha1-s+iWsTKjT8x37TkH79mkRE22Ilk=
+  integrity sha512-H7INDZk61mdwxr1l03UeBAh4f1QSTxxAGLxT7SRAxTMoWSK4Wv7q2XCdettYCPvSW3ApEcUlnz5QnZUOKi8oAg==
   dependencies:
     "@turf/bbox" "^4.7.3"
     "@turf/distance" "^4.7.3"
@@ -932,21 +950,21 @@
 "@turf/square@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/square/-/square-4.7.3.tgz#90391f7c1520ed62925488f466314426a5e4d33c"
-  integrity sha1-kDkffBUg7WKSVIj0ZjFEJqXk0zw=
+  integrity sha512-2upzaQMAWYgVuVj4jgR7t3yuXPcjVhbdh5KF2q4Caie2CiRKha9J7+lo+t2c1uD0XLj8uoWhQb9QxKdzyfRZ1w==
   dependencies:
     "@turf/distance" "^4.7.3"
 
 "@turf/tag@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/tag/-/tag-4.7.3.tgz#5a24fede581261f1c7c4f92a66815ba135942770"
-  integrity sha1-WiT+3lgSYfHHxPkqZoFboTWUJ3A=
+  integrity sha512-wmRKtb+VN8pNZ+z0EXjtJfuk6bXjUdxdT2L3kqfvYtNPE20W0Lx5LRT0eLEcYS8mmRX/qLhRhIGGgM05AUa+qw==
   dependencies:
     "@turf/inside" "^4.7.3"
 
 "@turf/tesselate@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/tesselate/-/tesselate-4.7.3.tgz#560af70c22f0b1de1f6c3b70e2bfdf3f844baced"
-  integrity sha1-Vgr3DCLwsd4fbDtw4r/fP4RLrO0=
+  integrity sha512-ykdjxUQWE9fAv8lNmNgUrERkIuQgeXWuSkvAS6pAbi8kqnUYRTXTPR+wQ/ACV+dkHLt0uznCkbUo6AxVO+ZNEA==
   dependencies:
     "@turf/helpers" "^4.7.3"
     earcut "^2.0.0"
@@ -954,14 +972,14 @@
 "@turf/tin@^4.4.0", "@turf/tin@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/tin/-/tin-4.7.3.tgz#6416209211e565539560dcf732858b701157ac7f"
-  integrity sha1-ZBYgkhHlZVOVYNz3MoWLcBFXrH8=
+  integrity sha512-eFLUkrpR9lf2uNZqObwJ7fmTr2PHvRpIXsfvJYNrf7e6q4lCEyWR20n1RdVSwRfOFr+H2vduMXRbNWxKNMB7bw==
   dependencies:
     "@turf/helpers" "^4.7.3"
 
 "@turf/transform-rotate@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/transform-rotate/-/transform-rotate-4.7.3.tgz#e07a837c27287265bf4910508677c50b8016bc67"
-  integrity sha1-4HqDfCcocmW/SRBQhnfFC4AWvGc=
+  integrity sha512-tJn7jmHy0s9WN2trZRggHWkpDx4LcuxunfaMtftsbrQcaLKNmYWapxhRZFm6QFpACDpK/d2baEfr+oml9eV+uA==
   dependencies:
     "@turf/centroid" "^4.7.3"
     "@turf/invariant" "^4.7.3"
@@ -973,7 +991,7 @@
 "@turf/transform-scale@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/transform-scale/-/transform-scale-4.7.3.tgz#f14d4ba992e58c9f33c0d71a96b834981c455ebc"
-  integrity sha1-8U1LqZLljJ8zwNcalrg0mBxFXrw=
+  integrity sha512-IrnMl5yjOdd757ec5T1inDDydzVthhX0yhbphhor4dixAByYw9XvX47FgGFNiU9e86Bz+rwV/gHrhGF0w4vuIg==
   dependencies:
     "@turf/bbox" "^4.7.3"
     "@turf/center" "^4.7.3"
@@ -989,7 +1007,7 @@
 "@turf/transform-translate@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/transform-translate/-/transform-translate-4.7.3.tgz#a7a2bc79e117b30af1e59de207a783585678b4ec"
-  integrity sha1-p6K8eeEXswrx5Z3iB6eDWFZ4tOw=
+  integrity sha512-dl1h2WSulCnvWipcMPE0pO0UcgS5ZaIn7wkROWltpwY2Ow/FKajx5NFyKtIP8cedgcFn4dLYYmp87FzV7JB4xw==
   dependencies:
     "@turf/invariant" "^4.7.3"
     "@turf/meta" "^4.7.3"
@@ -998,7 +1016,7 @@
 "@turf/triangle-grid@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/triangle-grid/-/triangle-grid-4.7.3.tgz#ced61311c51c0d1483ec038fedc9bbd0017e8900"
-  integrity sha1-ztYTEcUcDRSD7AOP7cm70AF+iQA=
+  integrity sha512-wtWWldYMtOdYu8lfzB8NlMqky87H6rqBkNqF2fTSb589RLtn15AWzHK66HboEgSCPFHaKqMjtJi2EE9TyMVbCA==
   dependencies:
     "@turf/distance" "^4.7.3"
     "@turf/helpers" "^4.7.3"
@@ -1006,14 +1024,14 @@
 "@turf/truncate@^4.4.0", "@turf/truncate@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/truncate/-/truncate-4.7.3.tgz#827a8df8ff0c9fff9dcf1a4b3145cbdef80fb993"
-  integrity sha1-gnqN+P8Mn/+dzxpLMUXL3vgPuZM=
+  integrity sha512-QVhn747oSOpZCT3JqfeBPsGYKzMCgzL6DygraeZCtOLkb7SNAkmr9dlNrqpgDIc8sQ5/TJR5D9r7Ohqn/xRJcA==
   dependencies:
     "@turf/meta" "^4.7.3"
 
 "@turf/turf@4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@turf/turf/-/turf-4.4.0.tgz#08c3b8007a20bd05421fdf2d63061ef6fd231b53"
-  integrity sha1-CMO4AHogvQVCH98tYwYe9v0jG1M=
+  integrity sha512-jjEs5OtB8Iyj+URTAwUOnqbuCdgvHBo9iEL7FJOWtCofxakNBFrmdimm8lgsQySTrU10CoJB9wcUT/UNNHh3zQ==
   dependencies:
     "@turf/along" "^4.4.0"
     "@turf/area" "^4.4.0"
@@ -1096,14 +1114,14 @@
 "@turf/union@^4.4.0", "@turf/union@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/union/-/union-4.7.3.tgz#012d4ac7465d6cad67fe4948d401b7f8be0fe412"
-  integrity sha1-AS1Kx0ZdbK1n/klI1AG3+L4P5BI=
+  integrity sha512-6mF3CJKJXGEUa9lNNM3yWc1dqEjEsoB92UoJPa0yr8zQOhgd4va1MoLh9QXHnWsGlevRa74Ob1e12mZxffcfdA==
   dependencies:
     jsts "1.3.0"
 
 "@turf/unkink-polygon@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/unkink-polygon/-/unkink-polygon-4.7.3.tgz#ca46bedf1f9f3b47f758f43a64f089414c974b93"
-  integrity sha1-yka+3x+fO0f3WPQ6ZPCJQUyXS5M=
+  integrity sha512-dHDmroMt7qqvr1WmhV5Q52p4ulpywDRCPR7P2ANV6af6JF/teKvHBXQnky0laMiEDLxBPmd/CRIccf6QhqfCXg==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/meta" "^4.7.3"
@@ -1112,7 +1130,7 @@
 "@turf/within@^3.13.0":
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/@turf/within/-/within-3.14.0.tgz#891a578323c292b9792269032dd74870e0e14c53"
-  integrity sha1-iRpXgyPCkrl5ImkDLddIcODhTFM=
+  integrity sha512-j4ljbcQrIqZ+slFDjk+BPlTITuNDNFy+o7l/ncAuiPMqcF1FOo5U4ztOpml/WmZgNeLT4Pr18rMMtp1RfBSrWQ==
   dependencies:
     "@turf/helpers" "^3.13.0"
     "@turf/inside" "^3.14.0"
@@ -1120,30 +1138,30 @@
 "@turf/within@^4.4.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/within/-/within-4.7.3.tgz#41ab3c152f6a8c05caa5a345c97dd334d49aef13"
-  integrity sha1-Qas8FS9qjAXKpaNFyX3TNNSa7xM=
+  integrity sha512-8uOT6U8GFeC84tMAHw9ViFiOY3JZI49/Xfmm3wk+P43unv0iEl20pIFjwRmF10G14d3ca2AcOxmxuXVYWRXvGA==
   dependencies:
     "@turf/helpers" "^4.7.3"
     "@turf/inside" "^4.7.3"
 
 "@types/cacheable-request@^6.0.1":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.2.tgz#c324da0197de0a98a2312156536ae262429ff6b9"
-  integrity sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.3.tgz#a430b3260466ca7b5ca5bfd735693b36e7a9d183"
+  integrity sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==
   dependencies:
     "@types/http-cache-semantics" "*"
-    "@types/keyv" "*"
+    "@types/keyv" "^3.1.4"
     "@types/node" "*"
-    "@types/responselike" "*"
+    "@types/responselike" "^1.0.0"
 
 "@types/http-cache-semantics@*":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
   integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
 
-"@types/keyv@*", "@types/keyv@^3.1.1":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.3.tgz#1c9aae32872ec1f20dcdaee89a9f3ba88f465e41"
-  integrity sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==
+"@types/keyv@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.4.tgz#3ccdb1c6751b0c7e52300bcdacd5bcbf8faa75b6"
+  integrity sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==
   dependencies:
     "@types/node" "*"
 
@@ -1153,16 +1171,16 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/node@*":
-  version "16.11.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
-  integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
+  version "20.4.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.8.tgz#b5dda19adaa473a9bf0ab5cbd8f30ec7d43f5c85"
+  integrity sha512-0mHckf6D2DiIAzh8fM8f3HQCvMKDpK94YQ0DSVkfWTG9BZleYIWudw9cJxX8oCk9bM+vAkDyujDV6dmKHbvQpg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
-"@types/responselike@*":
+"@types/responselike@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
@@ -1170,26 +1188,26 @@
     "@types/node" "*"
 
 "@types/unist@^2.0.0", "@types/unist@^2.0.2":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
-  integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.7.tgz#5b06ad6894b236a1d2bd6b2f07850ca5c59cf4d6"
+  integrity sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==
 
 "JSV@>= 4.0.x":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
-  integrity sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=
+  integrity sha512-ZJ6wx9xaKJ3yFUhq5/sk82PJMuUyLk277I8mQeyDgCTjGdjWJIvPfaU5LIXaMuaN2UO1X3kZH4+lgphublZUHw==
 
 affine-hull@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/affine-hull/-/affine-hull-1.0.0.tgz#763ff1d38d063ceb7e272f17ee4d7bbcaf905c5d"
-  integrity sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=
+  integrity sha512-3QNG6+vFAwJvSZHsJYDJ/mt1Cxx9n5ffA+1Ohmj7udw0JuRgUVIXK0P9N9pCMuEdS3jCNt8GFX5q2fChq+GO3Q==
   dependencies:
     robust-orientation "^1.1.3"
 
 ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.1.tgz#123d6479e92ad45ad897d4054e3c7ca7db4944e1"
+  integrity sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -1201,43 +1219,43 @@ ansi-styles@^3.2.1:
 ansi-styles@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
-  integrity sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=
+  integrity sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA==
 
-arches@archesproject/arches#stable/6.0.0:
-  version "6.0.0"
-  resolved "https://codeload.github.com/archesproject/arches/tar.gz/439f585093acec12e4ac4117f5cc98328e00a291"
+arches@archesproject/arches#stable/6.2.4:
+  version "6.2.4"
+  resolved "https://codeload.github.com/archesproject/arches/tar.gz/b09dc9c3875c13f5bd44dc8431065d88d8a533d8"
   dependencies:
-    "@mapbox/geojson-extent" "0.3.2"
+    "@mapbox/geojson-extent" "~1.0.1"
     "@mapbox/geojsonhint" "^3.0.0"
     "@mapbox/mapbox-gl-draw" "1.1.2"
     "@mapbox/mapbox-gl-geocoder" "^4.4.0"
     "@tmcw/togeojson" "^4.3.0"
     "@turf/turf" "4.4.0"
     backbone "1.3.3"
-    bootstrap "3.3.7"
-    bootstrap-colorpicker "^2.3.6"
+    bootstrap "3.4.1"
+    bootstrap-colorpicker "^2.5.3"
     chosen-js "1.8.7"
     ckeditor "^4.6.2"
-    codemirror "^5.24.0"
+    codemirror "^5.65.6"
     core-js "^2.5.7"
     cytoscape "^3.18.2"
     cytoscape-cola "^2.4.0"
     d3 "^6.1.1"
-    datatables.net "~1.10.12"
-    datatables.net-bs "~1.10.12"
-    datatables.net-buttons "^1.5.4"
-    datatables.net-buttons-bs "^1.5.4"
-    datatables.net-responsive "~2.1.0"
-    datatables.net-responsive-bs "~2.1.0"
+    datatables.net "~1.12.1"
+    datatables.net-bs "~1.12.1"
+    datatables.net-buttons "^2.2.3"
+    datatables.net-buttons-bs "^2.2.3"
+    datatables.net-responsive "~2.3.0"
+    datatables.net-responsive-bs "~2.3.0"
     dom4 "^2.0.1"
     dropzone "5.7.0"
-    eonasdan-bootstrap-datetimepicker "4.17.44"
+    eonasdan-bootstrap-datetimepicker "~4.17.49"
     font-awesome "~4.6.3"
     ionicons "~2.0.1"
     jqtree "1.3.4"
-    jquery "3.3.1"
-    jquery-migrate "3.0.0"
-    jquery-validation "1.17.0"
+    jquery "^3.6.1"
+    jquery-migrate "~3.4.1"
+    jquery-validation "1.19.5"
     jqueryui "1.11.1"
     js-cookie "2.1.1"
     knockout "3.5.0"
@@ -1251,58 +1269,53 @@ arches@archesproject/arches#stable/6.0.0:
     lt-themify-icons "^1.1.0"
     mapbox-gl "^1.8.1"
     metismenu "2.7.2"
-    moment ">=2.10.5"
-    moment-timezone "0.5.0"
+    moment "^2.29.4"
+    moment-timezone "~0.5.43"
     nouislider "11.0.3"
     numeral "^2.0.6"
     proj4 "^2.3.15"
     requirejs "~2.3.2"
     requirejs-plugins "1.0.2"
-    requirejs-text "2.0.12"
+    requirejs-text "~2.0.16"
     select2 "3.5.1"
-    underscore "1.9.1"
+    underscore "~1.13.6"
     uuidjs "^3.3.0"
 
 arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
-  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+  integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
 
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 backbone@1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.3.3.tgz#4cc80ea7cb1631ac474889ce40f2f8bc683b2999"
-  integrity sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=
+  integrity sha512-aK+k3TiU4tQDUrRCymDDE7XDFnMVuyE6zbZ4JX7mb4pJbQTVOH997/kyBzb8wB2s5Y/Oh7EUfj+sZhwRPxWwow==
   dependencies:
     underscore ">=1.8.3"
 
 base-64@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
-  integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
+  integrity sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==
 
 bit-twiddle@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bit-twiddle/-/bit-twiddle-1.0.2.tgz#0c6c1fabe2b23d17173d9a61b7b7093eb9e1769e"
-  integrity sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4=
+  integrity sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA==
 
-bootstrap-colorpicker@^2.3.6:
+bootstrap-colorpicker@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/bootstrap-colorpicker/-/bootstrap-colorpicker-2.5.3.tgz#b50aff8590fbaa6b5aa63a5624e4213f1659a49d"
   integrity sha512-xdllX8LSMvKULs3b8JrgRXTvyvjkSMHHHVuHjjN5FNMqr6kRe5NPiMHFmeAFjlgDF73MspikudLuEwR28LbzLw==
   dependencies:
     jquery ">=1.10"
 
-bootstrap@3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-  integrity sha1-WjiTlFSfIzMIdaOxUGVldPip63E=
-
-bootstrap@^3.3:
+bootstrap@3.4.1, bootstrap@^3.3:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
   integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
@@ -1312,18 +1325,15 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-cacheable-lookup@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz#87be64a18b925234875e10a9bb1ebca4adce6b38"
-  integrity sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==
-  dependencies:
-    "@types/keyv" "^3.1.1"
-    keyv "^4.0.0"
+cacheable-lookup@^5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
+  integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
 
-cacheable-request@^7.0.1:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27"
-  integrity sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==
+cacheable-request@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.4.tgz#7a33ebf08613178b403635be7b899d3e69bbe817"
+  integrity sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==
   dependencies:
     clone-response "^1.0.2"
     get-stream "^5.1.0"
@@ -1367,7 +1377,7 @@ chalk@^2.0.0:
 chalk@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
-  integrity sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=
+  integrity sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==
   dependencies:
     ansi-styles "~1.0.0"
     has-color "~0.1.0"
@@ -1384,16 +1394,16 @@ ckeditor@^4.6.2:
   integrity sha512-pH2Su4oi0D4iN/3U8nUcwI7/lXHoOJi0aiN8e2zxnm4Ow5kq8eZP2ZGmpYyuqRyKZ2tHaU8+OyYi7laXcjiq9Q==
 
 clone-response@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
-  integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.3.tgz#af2032aa47816399cf5f0a1d0db902f517abb8c3"
+  integrity sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==
   dependencies:
     mimic-response "^1.0.0"
 
-codemirror@^5.24.0:
-  version "5.63.3"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.63.3.tgz#97042a242027fe0c87c09b36bc01931d37b76527"
-  integrity sha512-1C+LELr+5grgJYqwZKqxrcbPsHFHapVaVAloBsFBASbpLnQqLw1U8yXJ3gT5D+rhxIiSpo+kTqN+hQ+9ialIXw==
+codemirror@^5.65.6:
+  version "5.65.14"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.65.14.tgz#e75fbc7247453f1baa71463c33b52adba7e41b2a"
+  integrity sha512-VSNugIBDGt0OU9gDjeVr6fNkoFQznrWEUdAApMlXQNbfE8gGO19776D6MwSqF/V/w/sDwonsQ0z7KmmI9guScg==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -1405,7 +1415,7 @@ color-convert@^1.9.0:
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -1432,7 +1442,7 @@ concat-stream@^1.6.1:
 convex-hull@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/convex-hull/-/convex-hull-1.0.3.tgz#20a3aa6ce87f4adea2ff7d17971c9fc1c67e1fff"
-  integrity sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=
+  integrity sha512-24rZAoh81t41GHPLAxcsokgjH9XNoVqU2OiSi8iMHUn6HUURfiefcEWAPt1AfwZjBBWTKadOm1xUcUMnfFukhQ==
   dependencies:
     affine-hull "^1.0.0"
     incremental-convex-hull "^1.0.1"
@@ -1451,22 +1461,22 @@ core-util-is@~1.0.0:
 csscolorparser@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/csscolorparser/-/csscolorparser-1.0.3.tgz#b34f391eea4da8f3e98231e2ccd8df9c041f171b"
-  integrity sha1-s085HupNqPPpgjHizNjfnAQfFxs=
+  integrity sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==
 
 cytoscape-cola@^2.4.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/cytoscape-cola/-/cytoscape-cola-2.5.0.tgz#7365d9dfc1a577dd068232093f2f00147c0c0155"
-  integrity sha512-TCpzO+e7H7Bhi2uiAi2Nq7gFwcSGkffe1J6uQ7Dsx6SLN9OhIzrQkBkV6m8kHzar+flVbP76RwxAa2y97jdphA==
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/cytoscape-cola/-/cytoscape-cola-2.5.1.tgz#1ec25dfd92533485f29943adf740ecd4feb2ea16"
+  integrity sha512-4/2S9bW1LvdsEPmxXN1OEAPFPbk7DvCx2c9d+TblkQAAvptGaSgtPWCByTEGgT8UxCxcVqes2aFPO5pzwo7R2w==
   dependencies:
     webcola "^3.4.0"
 
 cytoscape@^3.18.2:
-  version "3.20.0"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.20.0.tgz#c626c1074f3a8a6f1bc58e8fbee8fd798a6fcbf3"
-  integrity sha512-V2OUoav8ltY9UPgdjuhQOqkkWT28IbJODioWCjcnLqmjym9lMpnD0ie0vdQCdAiZapjbTGAv8aoKmmSuVcC1gA==
+  version "3.26.0"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.26.0.tgz#b4c6961445fd51e1fd3cca83c3ffe924d9a8abc9"
+  integrity sha512-IV+crL+KBcrCnVVUCZW+zRRRFUZQcrtdOPXki+o4CFUWLdAEYvuZLcBSJC9EBK++suamERKzeY7roq2hdovV3w==
   dependencies:
     heap "^0.2.6"
-    lodash.debounce "^4.0.8"
+    lodash "^4.17.21"
 
 d3-array@1:
   version "1.2.4"
@@ -1759,75 +1769,75 @@ d3@^6.1.1:
     d3-transition "2"
     d3-zoom "2"
 
-datatables.net-bs@>=1.10.9, datatables.net-bs@^1.10.15:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/datatables.net-bs/-/datatables.net-bs-1.11.3.tgz#4bca92330474733e0936db631fc12021f257a095"
-  integrity sha512-Db1YwAhO0QAWQbZTsKriUrOInT66+xaA+fV616KTKpQt5Zt+p6OsEKK+xv8LxLgG8qu5dPwMBlkhqSiS/hV2sg==
+datatables.net-bs@>=1.11.3, datatables.net-bs@>=1.13.4:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/datatables.net-bs/-/datatables.net-bs-1.13.6.tgz#d30f9da4a1304e34076521b77605cce993d6bedf"
+  integrity sha512-ohESuDtcrrNH56vGTErMUQklkzOVvKC5wyuaDApMruYc542IvESfalMOWKOChcAhGkhyXP9P9ZEr0AaDqQ7+Qw==
   dependencies:
-    datatables.net ">=1.10.25"
+    datatables.net ">=1.13.4"
     jquery ">=1.7"
 
-datatables.net-bs@~1.10.12:
-  version "1.10.25"
-  resolved "https://registry.yarnpkg.com/datatables.net-bs/-/datatables.net-bs-1.10.25.tgz#649f6d77088584f973ba17629b89874a52e9474a"
-  integrity sha512-05TPFg9+l8bhLDA1cezCq0pIGFaglD7uTkTuS0sN6DTArKQbT8bXkEvMcegFNWh7UMISQsTrGE/Vw3aWr1vgkg==
+datatables.net-bs@~1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/datatables.net-bs/-/datatables.net-bs-1.12.1.tgz#8165516519aade3d49a0b562c617bcce794a00b9"
+  integrity sha512-oaX1mNhjnASo33mwv6QzgGxD3pAz69qAL+8YlCro3e7oMvszE6wJyprEt80vl8E/TiMp/UUvsaqsup1JZFfMBQ==
   dependencies:
-    datatables.net "1.10.25"
+    datatables.net ">=1.11.3"
     jquery ">=1.7"
 
-datatables.net-buttons-bs@^1.5.4:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/datatables.net-buttons-bs/-/datatables.net-buttons-bs-1.7.1.tgz#2fb0542902d6e127dd160b4e46731d3bffadc177"
-  integrity sha512-ulqfr9UvazGcuqfjNjPSlecCZ9CUzLVM7+7VmfdJgmhF5pPFfYyrUhcVIRgeDDcSlMSwu0QeJN/AeFoR+A92QQ==
+datatables.net-buttons-bs@^2.2.3:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/datatables.net-buttons-bs/-/datatables.net-buttons-bs-2.4.1.tgz#945c43d9ea05466192f96361d7a099cd4160cb4b"
+  integrity sha512-7UrFP4Hez0FpRKYkRJJOr9hIZUhr2PnwvcCKr3FRyzdlz3ntViMJbZZv+L97YmNeiRAom7gmnO1Nt9eAYtxuiw==
   dependencies:
-    datatables.net-bs "^1.10.15"
-    datatables.net-buttons "1.7.1"
+    datatables.net-bs ">=1.13.4"
+    datatables.net-buttons ">=2.3.6"
     jquery ">=1.7"
 
-datatables.net-buttons@1.7.1, datatables.net-buttons@^1.5.4:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/datatables.net-buttons/-/datatables.net-buttons-1.7.1.tgz#b701bda4bf4dd76ebc9238251c62d13c18b2bb34"
-  integrity sha512-D2OxZeR18jhSx+l0xcfAJzfUH7l3LHCu0e606fV7+v3hMhphOfljjZYLaiRmGiR9lqO/f5xE/w2a+OtG/QMavw==
+datatables.net-buttons@>=2.3.6, datatables.net-buttons@^2.2.3:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/datatables.net-buttons/-/datatables.net-buttons-2.4.1.tgz#a548943494a37b0b7907c7b9afcf3ebaa29c17aa"
+  integrity sha512-Z788xsbGW+YqJWgQYCzE5IsbY8MNIihhDP/LOefijEn7MM1/jf4sQdf/KRNHr/CWTFGfojGPz+GNdJh8appeQQ==
   dependencies:
-    datatables.net "^1.10.15"
+    datatables.net ">=1.13.4"
     jquery ">=1.7"
 
-datatables.net-responsive-bs@~2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/datatables.net-responsive-bs/-/datatables.net-responsive-bs-2.1.1.tgz#8770c0fad439a7839b1633cf454e01f227dde877"
-  integrity sha1-h3DA+tQ5p4ObFjPPRU4B8ifd6Hc=
+datatables.net-responsive-bs@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/datatables.net-responsive-bs/-/datatables.net-responsive-bs-2.3.0.tgz#52aafe8f61478a314317bdd8a1958e64db04bcf5"
+  integrity sha512-YK3in6otAGTP58NqTnvwIAA4jUpy+M8wT0hVXpoCCDKciDP68/5VWhsnjm2XN2w/zU3pnBS0D6uMF7+9gthCrQ==
   dependencies:
-    datatables.net-bs ">=1.10.9"
-    datatables.net-responsive ">=1.0.7"
+    datatables.net-bs ">=1.11.3"
+    datatables.net-responsive ">=2.2.9"
     jquery ">=1.7"
 
-datatables.net-responsive@>=1.0.7:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/datatables.net-responsive/-/datatables.net-responsive-2.2.9.tgz#846d4436691b13261e8e436dc988affe4d262f36"
-  integrity sha512-C+mOY/mG17zzaYPtgqAOsC4JlGddGkKmO/ADNEtNZ41bcPV1/3jJzkOWT3DCZ400NmkXLDz4WObWlPT8WCgfzg==
+datatables.net-responsive@>=2.2.9:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/datatables.net-responsive/-/datatables.net-responsive-2.5.0.tgz#56919903646648f362f58c25784794fb89effda1"
+  integrity sha512-GL7DFiRl5qqrp5ql54Psz92xTGPR0rMcrO3hzNxMfvcfpRGL5zFNTvMpTUh59Erm6u1+KoX+j+Ig1ZD3r0iFsA==
   dependencies:
-    datatables.net "^1.10.15"
+    datatables.net ">=1.13.4"
     jquery ">=1.7"
 
-datatables.net-responsive@~2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/datatables.net-responsive/-/datatables.net-responsive-2.1.1.tgz#cbbd617882267ab2663e9745ad1b4e748158ed11"
-  integrity sha1-y71heIImerJmPpdFrRtOdIFY7RE=
+datatables.net-responsive@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/datatables.net-responsive/-/datatables.net-responsive-2.3.0.tgz#2b8d894af5456f8c8a320eeac5e837a24d84e033"
+  integrity sha512-QA5QsD1sJQRQ7/IFi3rSd33O84f/Augz2KnaehjfuEANtK4KeC9Lbkut5tPuuMcK4jOpQPOOPYTbmfrt+tfh9w==
   dependencies:
-    datatables.net ">=1.10.9"
+    datatables.net ">=1.11.3"
     jquery ">=1.7"
 
-datatables.net@1.10.25, datatables.net@~1.10.12:
-  version "1.10.25"
-  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.10.25.tgz#fc03a239e08f91d1d64ba101aa54daf4086d162c"
-  integrity sha512-y0+C7all+MC/h1acwnjErhaJPjYGKpWTvbXrfEUbR8+P+nnhgjNn5nL1udgsTwBObMhlj1KITNBRrM/ZLSoj+Q==
+datatables.net@>=1.11.3, datatables.net@>=1.13.4:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.13.6.tgz#6e282adbbb2732e8df495611b8bb54e19f7a943e"
+  integrity sha512-rHNcnW+yEP9me82/KmRcid5eKrqPqW3+I/p1TwqCW3c/7GRYYkDyF6aJQOQ9DNS/pw+nyr4BVpjyJ3yoZXiFPg==
   dependencies:
     jquery ">=1.7"
 
-datatables.net@>=1.10.25, datatables.net@>=1.10.9, datatables.net@^1.10.15:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.11.3.tgz#80e691036efcd62467558ee64c07dd566cb761b4"
-  integrity sha512-VMj5qEaTebpNurySkM6jy6sGpl+s6onPK8xJhYr296R/vUBnz1+id16NVqNf9z5aR076OGcpGHCuiTuy4E05oQ==
+datatables.net@~1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.12.1.tgz#3e625e49a3341f605b0efb519fae94e37b278f24"
+  integrity sha512-e6XAMUoV41JdQPS/r9YRfRcmTPcCVvyZbWI+xog1Zg+kjVliMQbEkvWK5XFItmi64Cvwg+IqsZbTUJ1KSY3umA==
   dependencies:
     jquery ">=1.7"
 
@@ -1839,9 +1849,9 @@ debug@^2.6.3:
     ms "2.0.0"
 
 decamelize-keys@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
-  integrity sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.1.tgz#04a2d523b2f18d80d0158a43b895d56dff8d19d8"
+  integrity sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==
   dependencies:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
@@ -1849,14 +1859,14 @@ decamelize-keys@^1.1.0:
 decamelize@^1.1.0, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+  integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
-decompress-response@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-5.0.0.tgz#7849396e80e3d1eba8cb2f75ef4930f76461cb0f"
-  integrity sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
   dependencies:
-    mimic-response "^2.0.0"
+    mimic-response "^3.1.0"
 
 deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.1.1"
@@ -1875,12 +1885,13 @@ defer-to-connect@^2.0.0:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
-define-properties@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
-  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+define-properties@^1.1.3, define-properties@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
+  integrity sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==
   dependencies:
-    object-keys "^1.0.12"
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
 
 delaunator@4:
   version "4.0.1"
@@ -1890,7 +1901,7 @@ delaunator@4:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dom4@^2.0.1:
   version "2.1.6"
@@ -1902,15 +1913,10 @@ dropzone@5.7.0:
   resolved "https://registry.yarnpkg.com/dropzone/-/dropzone-5.7.0.tgz#8d1007f3ebcc6e6d64096823f854d898f7564ef2"
   integrity sha512-kOltiZXH5cO/72I22JjE+w6BoT6uaVLfWdFMsi1PMKFkU6BZWpqRwjnsRm0o6ANGTBuZar5Piu7m/CbKqRPiYg==
 
-duplexer3@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
-  integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
-
 earcut@^2.0.0, earcut@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.3.tgz#d44ced2ff5a18859568e327dd9c7d46b16f55cf4"
-  integrity sha512-iRDI1QeCQIhMCZk48DRDMVgQSSBDmbzzNhnxIo+pwx3swkfjMh6vh0nWLq1NdvGHLKH6wIrAM3vQWeTj6qeoug==
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.4.tgz#6d02fd4d68160c114825d06890a92ecaae60343a"
+  integrity sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -1919,13 +1925,13 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-eonasdan-bootstrap-datetimepicker@4.17.44:
-  version "4.17.44"
-  resolved "https://registry.yarnpkg.com/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.44.tgz#cf966f38e777294f72926bb34ed362d1ef861e63"
-  integrity sha1-z5ZvOOd3KU9ykmuzTtNi0e+GHmM=
+eonasdan-bootstrap-datetimepicker@~4.17.49:
+  version "4.17.49"
+  resolved "https://registry.yarnpkg.com/eonasdan-bootstrap-datetimepicker/-/eonasdan-bootstrap-datetimepicker-4.17.49.tgz#5534ba581c1e7eb988dbf773e2fed8a7f48cc76a"
+  integrity sha512-7KZeDpkj+A6AtPR3XjX8gAnRPUkPSfW0OmMANG1dkUOPMtLSzbyoCjDIdEcfRtQPU5X0D9Gob7wWKn0h4QWy7A==
   dependencies:
     bootstrap "^3.3"
-    jquery "^1.8.3 || ^2.0"
+    jquery "^3.5.1"
     moment "^2.10"
     moment-timezone "^0.4.0"
 
@@ -1939,7 +1945,7 @@ error-ex@^1.3.1:
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
 
 eventemitter3@^3.1.0:
   version "3.1.2"
@@ -1957,7 +1963,7 @@ find-up@^4.1.0:
 font-awesome@~4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.6.3.tgz#86933651540ee00874c664017f50f2172f6531a2"
-  integrity sha1-hpM2UVQO4Ah0xmQBf1DyFy9lMaI=
+  integrity sha512-I5rWuHv7MI5uYDGFT1SJohxdkTfks41QQ9fvMEzvBnWppsehXnoj8LNuW4MGtawSrHvApYVhCZSC7rk5wDycyw==
 
 form-data@^3.0.0:
   version "3.0.1"
@@ -1973,10 +1979,15 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+functions-have-names@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
 fuzzy@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/fuzzy/-/fuzzy-0.1.3.tgz#4c76ec2ff0ac1a36a9dccf9a00df8623078d4ed8"
-  integrity sha1-THbsL/CsGjap3M+aAN+GIweNTtg=
+  integrity sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==
 
 geodesy@1.1.2:
   version "1.1.2"
@@ -1986,7 +1997,7 @@ geodesy@1.1.2:
 geojson-dissolve@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/geojson-dissolve/-/geojson-dissolve-3.1.0.tgz#86823271680a1a381f3e72f02648bbcc710ecda1"
-  integrity sha1-hoIycWgKGjgfPnLwJki7zHEOzaE=
+  integrity sha512-JXHfn+A3tU392HA703gJbjmuHaQOAE/C1KzbELCczFRFux+GdY6zt1nKb1VMBHp4LWeE7gUY2ql+g06vJqhiwQ==
   dependencies:
     "@turf/meta" "^3.7.5"
     geojson-flatten "^0.2.1"
@@ -1997,7 +2008,7 @@ geojson-dissolve@3.1.0:
 geojson-equality@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/geojson-equality/-/geojson-equality-0.1.6.tgz#a171374ef043e5d4797995840bae4648e0752d72"
-  integrity sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=
+  integrity sha512-TqG8YbqizP3EfwP5Uw4aLu6pKkg6JQK9uq/XZ1lXQntvTHD1BBKJWhNpJ2M0ax6TuWMP3oyx6Oq7FCIfznrgpQ==
   dependencies:
     deep-equal "^1.0.0"
 
@@ -2009,10 +2020,15 @@ geojson-flatten@^0.2.1, geojson-flatten@~0.2.1:
     get-stdin "^6.0.0"
     minimist "1.2.0"
 
+geojson-flatten@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/geojson-flatten/-/geojson-flatten-1.1.1.tgz#601aae07ba6406281ebca683573dcda69eba04c7"
+  integrity sha512-k/6BCd0qAt7vdqdM1LkLfAy72EsLDy0laNwX0x2h49vfYCiQkRc4PSra8DNEdJ10EKRpwEvDXMb0dBknTJuWpQ==
+
 geojson-linestring-dissolve@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/geojson-linestring-dissolve/-/geojson-linestring-dissolve-0.0.1.tgz#08ab8cdf386e919d35a0eb38fa1c550e020838db"
-  integrity sha1-CKuM3zhukZ01oOs4+hxVDgIIONs=
+  integrity sha512-Y8I2/Ea28R/Xeki7msBcpMvJL2TaPfaPKP8xqueJfQ9/jEhps+iOJxOR2XCBGgVb12Z6XnDb1CMbaPfLepsLaw==
 
 geojson-polygon-self-intersections@^1.1.2:
   version "1.2.1"
@@ -2024,12 +2040,12 @@ geojson-polygon-self-intersections@^1.1.2:
 geojson-random@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/geojson-random/-/geojson-random-0.2.2.tgz#ab4838f126adc5e16f8f94e655def820f9119dbc"
-  integrity sha1-q0g48SatxeFvj5TmVd74IPkRnbw=
+  integrity sha512-/vZQ14mjKPG3LJ7bpyXsJ0aoz8NzvwpwwP//uBgbzIu2BCFd4uRagp1QvY3RAzRQsHOHyVh33dbYUYws7vOCkg==
 
 geojson-rbush@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/geojson-rbush/-/geojson-rbush-1.2.0.tgz#eca3b6a3afb899a453ef82d5e2373092e20d77e5"
-  integrity sha1-7KO2o6+4maRT74LV4jcwkuINd+U=
+  integrity sha512-iiMclCIFRNLuTNghpvKNd7K11D1esI21qJGuptk3w8frT8cgjtjBiCrQHL0aAhrOOUq8atbXuvY/dhtA3+tJdw==
   dependencies:
     "@turf/meta" "^4.6.0"
     rbush "^2.0.1"
@@ -2037,7 +2053,7 @@ geojson-rbush@^1.0.1:
 geojson-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/geojson-utils/-/geojson-utils-1.1.0.tgz#e8ffb4c81c0a75b3e306f5187265d6f23040f50b"
-  integrity sha1-6P+0yBwKdbPjBvUYcmXW8jBA9Qs=
+  integrity sha512-9irmjugYFrMvGjMw+qW5BQpghJO4ClFMDdPzVe2oDgtH2DhoKMaXqjIYPS5VpfrcnV0kOSrXcj8D9Izmr0AM9Q==
 
 geojson-vt@^3.2.1:
   version "3.2.1"
@@ -2047,23 +2063,24 @@ geojson-vt@^3.2.1:
 get-closest@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/get-closest/-/get-closest-0.0.4.tgz#269ac776d1e6022aa0fd586dd708e8a7d32269af"
-  integrity sha1-JprHdtHmAiqg/Vht1wjop9Miaa8=
+  integrity sha512-oMgZYUtnPMZB6XieXiUADpRIc5kfD+RPfpiYe9aIlEYGIcOx2mTGgKmUkctlLof/ANleypqOJRhQypbrh33DkA==
 
-get-intrinsic@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
-  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
+  integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
   dependencies:
     function-bind "^1.1.1"
     has "^1.0.3"
-    has-symbols "^1.0.1"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
 
 get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
-get-stream@^5.0.0, get-stream@^5.1.0:
+get-stream@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
@@ -2080,26 +2097,22 @@ gl-matrix@^3.2.1:
   resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.4.3.tgz#fc1191e8320009fd4d20e9339595c6041ddc22c9"
   integrity sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==
 
-got@^10.7.0:
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/got/-/got-10.7.0.tgz#62889dbcd6cca32cd6a154cc2d0c6895121d091f"
-  integrity sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==
+got@^11.8.5:
+  version "11.8.6"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.6.tgz#276e827ead8772eddbcfc97170590b841823233a"
+  integrity sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==
   dependencies:
-    "@sindresorhus/is" "^2.0.0"
-    "@szmarczak/http-timer" "^4.0.0"
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
     "@types/cacheable-request" "^6.0.1"
-    cacheable-lookup "^2.0.0"
-    cacheable-request "^7.0.1"
-    decompress-response "^5.0.0"
-    duplexer3 "^0.1.4"
-    get-stream "^5.0.0"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.2"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
     lowercase-keys "^2.0.0"
-    mimic-response "^2.1.0"
     p-cancelable "^2.0.0"
-    p-event "^4.0.0"
     responselike "^2.0.0"
-    to-readable-stream "^2.0.0"
-    type-fest "^0.10.0"
 
 grid-index@^1.1.0:
   version "1.1.0"
@@ -2109,7 +2122,7 @@ grid-index@^1.1.0:
 grid-to-matrix@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/grid-to-matrix/-/grid-to-matrix-1.2.0.tgz#b016df4d76f996e6b74663eab9ceb913546657e9"
-  integrity sha1-sBbfTXb5lua3RmPquc65E1RmV+k=
+  integrity sha512-kk7Z61HfvexDS8KxVnxU7XFiwgvRRoSKLYosUhe9Nl8eGkPgMHke7daavhNqonNgQsxpCRx9klbnlNSmGE3MPQ==
   dependencies:
     "@turf/helpers" "^4.1.0"
     "@turf/invariant" "^4.1.0"
@@ -2132,17 +2145,29 @@ hard-rejection@^2.1.0:
 has-color@~0.1.0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
-  integrity sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=
+  integrity sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw==
 
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
-has-symbols@^1.0.1, has-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
-  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
+
+has-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
+  integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
+
+has-symbols@^1.0.2, has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-tostringtag@^1.0.0:
   version "1.0.0"
@@ -2161,12 +2186,12 @@ has@^1.0.3:
 hat@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/hat/-/hat-0.0.3.tgz#bb014a9e64b3788aed8005917413d4ff3d502d8a"
-  integrity sha1-uwFKnmSzeIrtgAWRdBPU/z1QLYo=
+  integrity sha512-zpImx2GoKXy42fVDSEad2BPKuSQdLcqsCYa48K3zHSzM/ugWuYjLDr8IXxpVuL7uCLHw56eaiLxCRthhOzf5ug==
 
 heap@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
-  integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.7.tgz#1e6adf711d3f27ce35a81fe3b7bd576c2260a8fc"
+  integrity sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -2174,9 +2199,17 @@ hosted-git-info@^2.1.4:
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 http-cache-semantics@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
-  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
+  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
+
+http2-wrapper@^1.0.0-beta.5.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz#b8f55e0c1f25d4ebd08b3b0c2c079f9590800b3d"
+  integrity sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.0.0"
 
 iconv-lite@0.4:
   version "0.4.24"
@@ -2193,7 +2226,7 @@ ieee754@^1.1.12:
 incremental-convex-hull@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/incremental-convex-hull/-/incremental-convex-hull-1.0.1.tgz#51428c14cb9d9a6144bfe69b2851fb377334be1e"
-  integrity sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=
+  integrity sha512-mKRJDXtzo1R9LxCuB1TdwZXHaPaIEldoGPsXy2jrJc/kufyqp8y/VAQQxThSxM2aroLoh6uObexPk1ASJ7FB7Q==
   dependencies:
     robust-orientation "^1.1.2"
     simplicial-complex "^1.0.0"
@@ -2216,7 +2249,7 @@ internmap@^1.0.0:
 ionicons@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ionicons/-/ionicons-2.0.1.tgz#ca398113293ea870244f538f0aabbd4b5b209a3e"
-  integrity sha1-yjmBEyk+qHAkT1OPCqu9S1sgmj4=
+  integrity sha512-ySWjaL3PxB4JFMvr7/02sByWM7TQv1mrvRYFvUwFcVEEHEK/RKEP6MFhcnTmKhoPM6Ih6s5wH003fkVk1wiXLQ==
 
 is-arguments@^1.0.4:
   version "1.1.1"
@@ -2229,17 +2262,17 @@ is-arguments@^1.0.4:
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
-  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+  integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
 is-buffer@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
-is-core-module@^2.2.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
-  integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
+is-core-module@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
+  integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
   dependencies:
     has "^1.0.3"
 
@@ -2253,12 +2286,12 @@ is-date-object@^1.0.1:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
-  integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+  integrity sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==
 
 is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
-  integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+  integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
 
 is-regex@^1.0.4:
   version "1.1.4"
@@ -2271,51 +2304,39 @@ is-regex@^1.0.4:
 isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-  integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 jqtree@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/jqtree/-/jqtree-1.3.4.tgz#dd56ef3bc96d1098115392d41ef1b1f5aec47469"
-  integrity sha1-3VbvO8ltEJgRU5LUHvGx9a7EdGk=
+  integrity sha512-iHEF7ZEQMTIeikxMstYVWbiWQSBBVAI5veKJZ5uYPpk843+hDXZfMhgT89k64fba/KkG0O6mcZ85JYnvIBH0hQ==
   dependencies:
     jquery ">=1.9"
 
-jquery-migrate@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/jquery-migrate/-/jquery-migrate-3.0.0.tgz#03f320596fe1a1db09cdcfb74b14571994aad7bb"
-  integrity sha1-A/MgWW/hodsJzc+3SxRXGZSq17s=
+jquery-migrate@~3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery-migrate/-/jquery-migrate-3.4.1.tgz#6a7114626b80e0d9e1cb77f170623efd85c5fc9c"
+  integrity sha512-6RaV23lLAYccu8MtLfy2sIxOvx+bulnWHm/pvffAi7KOzPk1sN9IYglpkl1ZNCj1FSgSNDPS2fSZ1hWsXc200Q==
 
-jquery-validation@1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/jquery-validation/-/jquery-validation-1.17.0.tgz#ab66b6b583d7740b9bbd148993e50e8ac041f35b"
-  integrity sha512-XddiAwhGdWhcIJ+W3ri3KG8uTPMua4TPYuUIC8/E7lOyqdScG5xHuy9YishlKc0c/lIQai77EX7hxMdTSYCEjA==
-  dependencies:
-    jquery "^1.7 || ^2.0 || ^3.1"
+jquery-validation@1.19.5:
+  version "1.19.5"
+  resolved "https://registry.yarnpkg.com/jquery-validation/-/jquery-validation-1.19.5.tgz#557495b7cad79716897057c4447ad3cd76fda811"
+  integrity sha512-X2SmnPq1mRiDecVYL8edWx+yTBZDyC8ohWXFhXdtqFHgU9Wd4KHkvcbCoIZ0JaSaumzS8s2gXSkP8F7ivg/8ZQ==
 
-jquery@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
-
-jquery@>=1.10, jquery@>=1.7, jquery@>=1.9, jquery@>=1.9.0, "jquery@^1.7 || ^2.0 || ^3.1":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
-
-"jquery@^1.8.3 || ^2.0":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
-  integrity sha1-LInWiJterFIqfuoywUUhVZxsvwI=
+jquery@>=1.10, jquery@>=1.7, jquery@>=1.9, jquery@>=1.9.0, jquery@^3.5.1, jquery@^3.6.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.0.tgz#fe2c01a05da500709006d8790fe21c8a39d75612"
+  integrity sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ==
 
 jqueryui@1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/jqueryui/-/jqueryui-1.11.1.tgz#8718550705f5568d1199196169094db73b2291bc"
-  integrity sha1-hxhVBwX1Vo0RmRlhaQlNtzsikbw=
+  integrity sha512-w3k80seYwcirTMG7fhd1MfqYx2dMO9fEi+I0vUN5hbX5+y7YIWySJkFsCBj4UBNuFcYOfUk6I63sUG/hCawdZA==
 
 js-cookie@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.1.1.tgz#26ada7902e91fe7f8bb01b4831912c724739f381"
-  integrity sha1-Jq2nkC6R/n+LsBtIMZEsckc584E=
+  integrity sha512-BYjLHmXr/YFnH1x+wmK5qSSsag7bKRF7JDp6BRBsSjIXOnZoI6Y+JrmlCqN99/9MQq/Dim/cc949wwkEJCuPnQ==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -2335,7 +2356,7 @@ json-parse-even-better-errors@^2.3.0:
 jsonlint-lines@1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/jsonlint-lines/-/jsonlint-lines-1.7.1.tgz#507de680d3fb8c4be1641cc57d6f679f29f178ff"
-  integrity sha1-UH3mgNP7jEvhZBzFfW9nnynxeP8=
+  integrity sha512-Xp9w20GzfOiwabOqi3bH4Gnx85WFwpaWebmaspaDwX9fBISlEnKYoMtIR9bu6OGFIKzt50BRVyXLxRKDZXQ8Hg==
   dependencies:
     JSV ">= 4.0.x"
     nomnom ">= 1.5.x"
@@ -2343,7 +2364,7 @@ jsonlint-lines@1.7.1:
 jsts@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsts/-/jsts-1.3.0.tgz#e93a76f97ac9bda7d4625d9d6470f0d60ac80e45"
-  integrity sha1-6Tp2+XrJvafUYl2dZHDw1grIDkU=
+  integrity sha512-uFcaiZ5ba3Y6lfHNFikk64Kdkfx01iq3GE+K2S2k95uDcJcKxMusMd2RGgYWeS8EeUVX6eadOqwEzwA8yyGOaQ==
 
 kdbush@^3.0.0:
   version "3.0.0"
@@ -2351,9 +2372,9 @@ kdbush@^3.0.0:
   integrity sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==
 
 keyv@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.3.tgz#4f3aa98de254803cafcd2896734108daa35e4254"
-  integrity sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.3.tgz#00873d2b046df737963157bd04f294ca818c9c25"
+  integrity sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==
   dependencies:
     json-buffer "3.0.1"
 
@@ -2365,7 +2386,7 @@ kind-of@^6.0.3:
 knockout-mapping@~2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/knockout-mapping/-/knockout-mapping-2.6.0.tgz#052759d01ecf30d4947e8ebe64ad2c82933f06ff"
-  integrity sha1-BSdZ0B7PMNSUfo6+ZK0sgpM/Bv8=
+  integrity sha512-Q4dh1RSU/54TRCbZCYCBHC462T64fgnYly6UOyzDA2h8CEgthtN/AL6rXYVmoKYTbRtfvVHyLalKztVOe85Pmw==
 
 knockout@3.5.0:
   version "3.5.0"
@@ -2380,7 +2401,7 @@ knockout@>=2.3.0:
 knockstrap@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/knockstrap/-/knockstrap-1.3.2.tgz#546b713dc8eee9cf56900f9a772d8e51e67aab06"
-  integrity sha1-VGtxPcju6c9WkA+ady2OUeZ6qwY=
+  integrity sha512-n6Hr+LpywJ6g/lrWfvZrG+FXwkXvfgPAw9ZY9cwIPejv+ZrfeRv8NmfOSr96Zndv4dH0ODu8esXh6OVk6/uYvQ==
   dependencies:
     jquery ">=1.9.0"
     knockout ">=2.3.0"
@@ -2389,7 +2410,7 @@ knockstrap@1.3.2:
 latlon-geohash@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/latlon-geohash/-/latlon-geohash-1.1.0.tgz#7abe15224c4800e3eaecac71c753a20bfb6cbf65"
-  integrity sha1-er4VIkxIAOPq7Kxxx1OiC/tsv2U=
+  integrity sha512-K1zIBU1Wtdw0Uam+Jvu4eC7mq+XBeZ/cTVGRczfE8Wbhb0pZ7+m+gbrlu0sN2i4MkHMxRu/jBc3XKo4wMXxIlg==
 
 leaflet-draw@^1.0.4:
   version "1.0.4"
@@ -2414,12 +2435,12 @@ leaflet@1.6.0:
 lineclip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/lineclip/-/lineclip-1.1.5.tgz#2bf26067d94354feabf91e42768236db5616fd13"
-  integrity sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM=
+  integrity sha512-KlA/wRSjpKl7tS9iRUdlG72oQ7qZ1IlVbVgHwoO10TBR/4gQ86uhKow6nlzMAJJhjCWKto8OeoAzzIzKSmN25A==
 
 lines-and-columns@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
-  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
+  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -2428,15 +2449,20 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.debounce@^4.0.6, lodash.debounce@^4.0.8:
+lodash.debounce@^4.0.6:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
 lodash.isequal@^4.2.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lowercase-keys@^2.0.0:
   version "2.0.0"
@@ -2446,12 +2472,12 @@ lowercase-keys@^2.0.0:
 lt-themify-icons@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/lt-themify-icons/-/lt-themify-icons-1.1.0.tgz#945401d5a7205eff653ad5ef4ce94b912ba98c58"
-  integrity sha1-lFQB1acgXv9lOtXvTOlLkSupjFg=
+  integrity sha512-/9PcTKSq6GdUw+bfzeStjOUgsaOmZEwrxwVCmA9CtORgUgKQNCSxKCwgIpDz81IRgBPG7Ob5DefYqINhULsn1g==
 
 map-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
-  integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
+  integrity sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==
 
 map-obj@^4.0.0:
   version "4.3.0"
@@ -2459,11 +2485,11 @@ map-obj@^4.0.0:
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
 mapbox-gl@^1.8.1:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.13.2.tgz#76639c44f141f8dff71b7d8f1504f2aed11f7517"
-  integrity sha512-CPjtWygL+f7naL+sGHoC2JQR0DG7u+9ik6WdkjjVmz2uy0kBC2l+aKfdi3ZzUR7VKSQJ6Mc/CeCN+6iVNah+ww==
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.13.3.tgz#e024829cfc353f6e99275592061d15dfd7f41a71"
+  integrity sha512-p8lJFEiqmEQlyv+DQxFAOG/XPWN0Wp7j/Psq93Zywz7qt9CcUKFYDBOoOEKzqe6gudHVJY8/Bhqw6VDpX2lSBg==
   dependencies:
-    "@mapbox/geojson-rewind" "^0.5.0"
+    "@mapbox/geojson-rewind" "^0.5.2"
     "@mapbox/geojson-types" "^1.0.2"
     "@mapbox/jsonlint-lines-primitives" "^2.0.2"
     "@mapbox/mapbox-gl-supported" "^1.5.0"
@@ -2477,7 +2503,6 @@ mapbox-gl@^1.8.1:
     geojson-vt "^3.2.1"
     gl-matrix "^3.2.1"
     grid-index "^1.1.0"
-    minimist "^1.2.5"
     murmurhash-js "^1.0.0"
     pbf "^3.2.1"
     potpack "^1.0.1"
@@ -2490,7 +2515,7 @@ mapbox-gl@^1.8.1:
 marchingsquares@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/marchingsquares/-/marchingsquares-1.2.0.tgz#36ae2dcc170be576d42579aac3c46da89ab650e6"
-  integrity sha1-Nq4tzBcL5XbUJXmqw8RtqJq2UOY=
+  integrity sha512-qWXJDs9flDf6Ias8eb9kK4z2QL/QlIhXVJgFoADmw59gh3zMInybvMx23hMQ62moMfpRuMJQ3ZZVuHN086x5Pw==
 
 marchingsquares@^1.2.0:
   version "1.3.3"
@@ -2522,29 +2547,29 @@ metismenu@2.7.2:
 mgrs@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mgrs/-/mgrs-1.0.0.tgz#fb91588e78c90025672395cb40b25f7cd6ad1829"
-  integrity sha1-+5FYjnjJACVnI5XLQLJffNatGCk=
+  integrity sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==
 
-mime-db@1.50.0:
-  version "1.50.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.50.0.tgz#abd4ac94e98d3c0e185016c67ab45d5fde40c11f"
-  integrity sha512-9tMZCDlYHqeERXEHO9f/hKfNXhre5dK2eE/krIvUjZbS2KPcqGDfNShIWS1uW9XOTKQKqK6qbeOci18rbfW77A==
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
 mime-types@^2.1.12:
-  version "2.1.33"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.33.tgz#1fa12a904472fafd068e48d9e8401f74d3f70edb"
-  integrity sha512-plLElXp7pRDd0bNZHw+nMd52vRYjLwQjygaNg7ddJ2uJtTlmnTCjWuPKxVu6//AdaRuME84SvLW91sIkBqGT0g==
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
-    mime-db "1.50.0"
+    mime-db "1.52.0"
 
 mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-mimic-response@^2.0.0, mimic-response@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
-  integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
 min-indent@^1.0.0:
   version "1.0.1"
@@ -2563,48 +2588,48 @@ minimist-options@^4.0.2:
 minimist@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+  integrity sha512-7Wl+Jz+IGWuSdgsQEJ4JunV0si/iMhg42MnQQG6h1R6TNeVenp4U9x5CC5v/gYqz/fENLQITAWXidNtVL0NNbw==
 
-minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-moment-timezone@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.0.tgz#f282c8e5e6e28614b2f6dd1048663754d30ea11f"
-  integrity sha1-8oLI5ebihhSy9t0QSGY3VNMOoR8=
-  dependencies:
-    moment ">= 2.6.0"
+minimist@^1.2.6, minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 moment-timezone@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.4.1.tgz#81f598c3ad5e22cdad796b67ecd8d88d0f5baa06"
-  integrity sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=
+  integrity sha512-5cNPVUwaVJDCe9JM8m/qz17f9SkaI8rpnRUyDJi2K5HAd6EwhuQ3n5nLclZkNC/qJnomKgQH2TIu70Gy2dxFKA==
   dependencies:
     moment ">= 2.6.0"
 
-"moment@>= 2.6.0", moment@>=2.10.5, moment@^2.10:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+moment-timezone@~0.5.43:
+  version "0.5.43"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.43.tgz#3dd7f3d0c67f78c23cd1906b9b2137a09b3c4790"
+  integrity sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==
+  dependencies:
+    moment "^2.29.4"
+
+"moment@>= 2.6.0", moment@^2.10, moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 monotone-convex-hull-2d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz#47f5daeadf3c4afd37764baa1aa8787a40eee08c"
-  integrity sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=
+  integrity sha512-ixQ3qdXTVHvR7eAoOjKY8kGxl9YjOFtzi7qOjwmFFPfBqZHVOjUFOBy/Dk9dusamRSPJe9ggyfSypRbs0Bl8BA==
   dependencies:
     robust-orientation "^1.1.3"
 
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
 murmurhash-js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
-  integrity sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E=
+  integrity sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==
 
 nanoid@^2.0.1:
   version "2.1.11"
@@ -2614,7 +2639,7 @@ nanoid@^2.0.1:
 "nomnom@>= 1.5.x":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
-  integrity sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=
+  integrity sha512-5s0JxqhDx9/rksG2BTMVN1enjWSvPidpoSgViZU4ZXULyTe+7jxcCRLB6f42Z0l1xYJpleCBtSyY6Lwg3uu5CQ==
   dependencies:
     chalk "~0.4.0"
     underscore "~1.6.0"
@@ -2642,7 +2667,7 @@ nouislider@11.0.3:
 numeral@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/numeral/-/numeral-2.0.6.tgz#4ad080936d443c2561aed9f2197efffe25f4e506"
-  integrity sha1-StCAk21EPCVhrtnyGX7//iX05QY=
+  integrity sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==
 
 object-is@^1.0.1:
   version "1.1.5"
@@ -2652,7 +2677,7 @@ object-is@^1.0.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -2660,7 +2685,7 @@ object-keys@^1.0.12, object-keys@^1.1.1:
 once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
 
@@ -2668,18 +2693,6 @@ p-cancelable@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
   integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
-
-p-event@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/p-event/-/p-event-4.2.0.tgz#af4b049c8acd91ae81083ebd1e6f5cae2044c1b5"
-  integrity sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==
-  dependencies:
-    p-timeout "^3.1.0"
-
-p-finally@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-  integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -2694,13 +2707,6 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
-
-p-timeout@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
-  dependencies:
-    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -2722,7 +2728,7 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-parse@^1.0.6:
+path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -2738,7 +2744,7 @@ pbf@^3.2.1:
 polygonize@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/polygonize/-/polygonize-1.0.1.tgz#51fb7040914be0fbc43b0bd54d421d75fc2ae7a6"
-  integrity sha1-UftwQJFL4PvEOwvVTUIddfwq56Y=
+  integrity sha512-vVkeF4ju+QEuutzMwnt4t1oGt8CbbfyszSU2t+UTzupfsOFH3IWTINHuY2+Lwz4D+SufwlLIJwHd5XdxMO9XDw==
   dependencies:
     "@turf/envelope" "^4.3.0"
     "@turf/helpers" "^4.3.0"
@@ -2757,9 +2763,9 @@ process-nextick-args@~2.0.0:
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 proj4@^2.3.15:
-  version "2.7.5"
-  resolved "https://registry.yarnpkg.com/proj4/-/proj4-2.7.5.tgz#46c3ef841a9df57470d791f221160a9d68951945"
-  integrity sha512-5ecXUXbHAfvdhfBQpU7EhUfPCQGUCPmVup/4gnZA3bJY3JcK/xxzm4QQDz1xiXokN6ux65VDczlCtBtKrTSpAQ==
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/proj4/-/proj4-2.9.0.tgz#1b61db8c998313f80e2514609b339fb2d28cbb82"
+  integrity sha512-BoDXEzCVnRJVZoOKA0QHTFtYoE8lUxtX1jST38DJ8U+v1ixY70Kpwi0Llu6YqSWEH2xqu4XMEBNGcgeRIEywoA==
   dependencies:
     mgrs "1.0.0"
     wkt-parser "^1.3.1"
@@ -2781,6 +2787,11 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
 quickselect@^1.0.1:
   version "1.1.1"
@@ -2819,9 +2830,9 @@ read-pkg@^5.2.0:
     type-fest "^0.6.0"
 
 readable-stream@^2.2.2:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -2840,32 +2851,38 @@ redent@^3.0.0:
     strip-indent "^3.0.0"
 
 regexp.prototype.flags@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
-  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
+  integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
   dependencies:
     call-bind "^1.0.2"
-    define-properties "^1.1.3"
+    define-properties "^1.2.0"
+    functions-have-names "^1.2.3"
 
 repeat-string@^1.5.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
-  integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+  integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
 requirejs-plugins@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/requirejs-plugins/-/requirejs-plugins-1.0.2.tgz#693b5589d97f8598462fc71826353262aafda836"
-  integrity sha1-aTtVidl/hZhGL8cYJjUyYqr9qDY=
+  integrity sha512-bX1vGnjDd1iIod3hst47oM/Nv9JiYw4qodWNKgyeQw5ahzSvPI3j1K6hMcK0HtiGRKxebCf+QUrtWzbrZtzQog==
 
-requirejs-text@2.0.12:
-  version "2.0.12"
-  resolved "https://registry.yarnpkg.com/requirejs-text/-/requirejs-text-2.0.12.tgz#d7915d50e30ef355a53a8123f12a5e760a601eb8"
-  integrity sha1-15FdUOMO81WlOoEj8SpedgpgHrg=
+requirejs-text@~2.0.16:
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/requirejs-text/-/requirejs-text-2.0.16.tgz#b6f3e20689aa998e36641bc4f8bd11b7964ac872"
+  integrity sha512-XrzjeTb1pwzIWmkz8qnUiM20gENgiwB+66IciNuziwlaPAJsYQsQPSYyQ1kD4tGKGZxTisIfDbOHk02DpI/76Q==
 
 requirejs@~2.3.2:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/requirejs/-/requirejs-2.3.6.tgz#e5093d9601c2829251258c0b9445d4d19fa9e7c9"
   integrity sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==
+
+resolve-alpn@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
+  integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
 
 resolve-protobuf-schema@^2.1.0:
   version "2.1.0"
@@ -2875,17 +2892,18 @@ resolve-protobuf-schema@^2.1.0:
     protocol-buffers-schema "^3.3.1"
 
 resolve@^1.10.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
-  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  version "1.22.4"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.4.tgz#1dc40df46554cdaf8948a486a10f6ba1e2026c34"
+  integrity sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==
   dependencies:
-    is-core-module "^2.2.0"
-    path-parse "^1.0.6"
+    is-core-module "^2.13.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 responselike@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
-  integrity sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.1.tgz#9a0bc8fdc252f3fb1cca68b016591059ba1422bc"
+  integrity sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==
   dependencies:
     lowercase-keys "^2.0.0"
 
@@ -2902,7 +2920,7 @@ robust-orientation@^1.1.2, robust-orientation@^1.1.3:
 robust-scale@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/robust-scale/-/robust-scale-1.0.2.tgz#775132ed09542d028e58b2cc79c06290bcf78c32"
-  integrity sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=
+  integrity sha512-jBR91a/vomMAzazwpsPTPeuTPPmWBacwA+WYGNKcRGSh6xweuQ2ZbjRZ4v792/bZOhRKXRiQH0F48AvuajY0tQ==
   dependencies:
     two-product "^1.0.2"
     two-sum "^1.0.0"
@@ -2910,22 +2928,22 @@ robust-scale@^1.0.2:
 robust-subtract@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/robust-subtract/-/robust-subtract-1.0.0.tgz#e0b164e1ed8ba4e3a5dda45a12038348dbed3e9a"
-  integrity sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo=
+  integrity sha512-xhKUno+Rl+trmxAIVwjQMiVdpF5llxytozXJOdoT4eTIqmqsndQqFb1A0oiW3sZGlhMRhOi6pAD4MF1YYW6o/A==
 
 robust-sum@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/robust-sum/-/robust-sum-1.0.0.tgz#16646e525292b4d25d82757a286955e0bbfa53d9"
-  integrity sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k=
+  integrity sha512-AvLExwpaqUqD1uwLU6MwzzfRdaI6VEZsyvQ3IAQ0ZJ08v1H+DTyqskrf2ZJyh0BDduFVLN7H04Zmc+qTiahhAw==
 
 rw@1, rw@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
-  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
+  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
 rw@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/rw/-/rw-0.1.4.tgz#4903cbd80248ae0ede685bf58fd236a7a9b29a3e"
-  integrity sha1-SQPL2AJIrg7eaFv1j9I2p6mymj4=
+  integrity sha512-vSj3D96kMcjNyqPcp65wBRIDImGSrUuMxngNNxvw8MQaO+aQ6llzRPH7XcJy5zrpb3wU++045+Uz/IDIM684iw==
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -2940,17 +2958,17 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
 select2@3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/select2/-/select2-3.5.1.tgz#f2819489bbc65fd6d328be72bbe2b95dd7e87cfe"
-  integrity sha1-8oGUibvGX9bTKL5yu+K5XdfofP4=
+  integrity sha512-IFX3UFPpPyK1I1Kuw1R1x+upMyNAZbMlkFhiTnRCRR7ii0KU1brmJMLa3GZcrMWCHiQlm0eKqb6i4XO4pqOrGQ==
 
 "semver@2 || 3 || 4 || 5":
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 simplepolygon@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/simplepolygon/-/simplepolygon-1.2.1.tgz#48250a6a853275e96e42c7105f507da00dc67d64"
-  integrity sha1-SCUKaoUydeluQscQX1B9oA3GfWQ=
+  integrity sha512-9XAZs9bo14woAWSFRMMOLHk3nFn4nudLDV2kYL/nDWYC2Gl7aEmhKtS0+nb5w4bXlFsZU5clRA0rrEnGRo1nnQ==
   dependencies:
     "@turf/area" "^3.13.0"
     "@turf/helpers" "^3.13.0"
@@ -2963,7 +2981,7 @@ simplepolygon@1.2.1:
 simplicial-complex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/simplicial-complex/-/simplicial-complex-1.0.0.tgz#6c33a4ed69fcd4d91b7bcadd3b30b63683eae241"
-  integrity sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=
+  integrity sha512-mHauIKSOy3GquM5VnYEiu7eP5y4A8BiaN9ezUUgyYFz1k68PqDYcyaH3kenp2cyvWZE96QKE3nrxYw65Allqiw==
   dependencies:
     bit-twiddle "^1.0.0"
     union-find "^1.0.0"
@@ -2974,9 +2992,9 @@ simplify-js@^1.2.1:
   integrity sha512-vITfSlwt7h/oyrU42R83mtzFpwYk3+mkH9bOHqq/Qw6n8rtR7aE3NZQ5fbcyCUVVmuMJR6ynsAhOfK2qoah8Jg==
 
 spdx-correct@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
-  integrity sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.2.0.tgz#4f5ab0668f0059e34f9c00dce331784a12de4e9c"
+  integrity sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
@@ -2995,9 +3013,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.10"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz#0d9becccde7003d6c658d487dd48a32f0bf3014b"
-  integrity sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz#7189a474c46f8d47c7b0da4b987bb45e908bd2d5"
+  integrity sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==
 
 string-width@^2.0.0:
   version "2.1.1"
@@ -3017,14 +3035,14 @@ string_decoder@~1.1.1:
 strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
 
 strip-ansi@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
-  integrity sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=
+  integrity sha512-behete+3uqxecWlDAm5lmskaSaISA+ThQ4oNNBDTBJt0x2ppR6IPqfZNuj6BLaLJ/Sji4TPZlcRyOis8wXQTLg==
 
 strip-indent@^3.0.0:
   version "3.0.0"
@@ -3047,9 +3065,9 @@ suggestions@^1.6.0:
     xtend "^4.0.0"
 
 supercluster@^7.1.0:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.1.4.tgz#6762aabfd985d3390b49f13b815567d5116a828a"
-  integrity sha512-GhKkRM1jMR6WUwGPw05fs66pOFWhf59lXq+Q3J3SxPvhNcmgOtLRV6aVQPMRsmXdpaeFJGivt+t7QXUPL3ff4g==
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.1.5.tgz#65a6ce4a037a972767740614c19051b64b8be5a3"
+  integrity sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==
   dependencies:
     kdbush "^3.0.0"
 
@@ -3060,15 +3078,15 @@ supports-color@^5.0.0, supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 tinyqueue@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
   integrity sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==
-
-to-readable-stream@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-2.1.0.tgz#82880316121bea662cdc226adb30addb50cb06e8"
-  integrity sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==
 
 topojson-client@^3.0.0:
   version "3.1.0"
@@ -3085,9 +3103,9 @@ topojson-server@^3.0.0:
     commander "2"
 
 traverse@~0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
-  integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.7.tgz#46961cd2d57dd8706c36664acde06a248f1173fe"
+  integrity sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg==
 
 trim-newlines@^3.0.0:
   version "3.0.1"
@@ -3097,22 +3115,17 @@ trim-newlines@^3.0.0:
 twitter-bootstrap-3.0.0@~3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/twitter-bootstrap-3.0.0/-/twitter-bootstrap-3.0.0-3.0.0.tgz#30a24297b48373f93cd9abe10fd9924415c3d17a"
-  integrity sha1-MKJCl7SDc/k82avhD9mSRBXD0Xo=
+  integrity sha512-i5vrzu+Wl6PGKraJAaPx6nDUTS/v/E+oqS/SUtsfp259HD85yBK/ZROrU8dG0wQatzG4rmFmjUNbIcHH6Yv8yA==
 
 two-product@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/two-product/-/two-product-1.0.2.tgz#67d95d4b257a921e2cb4bd7af9511f9088522eaa"
-  integrity sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo=
+  integrity sha512-vOyrqmeYvzjToVM08iU52OFocWT6eB/I5LUWYnxeAPGXAhAxXYU/Yr/R2uY5/5n4bvJQL9AQulIuxpIsMoT8XQ==
 
 two-sum@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/two-sum/-/two-sum-1.0.0.tgz#31d3f32239e4f731eca9df9155e2b297f008ab64"
-  integrity sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q=
-
-type-fest@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.10.0.tgz#7f06b2b9fbfc581068d1341ffabd0349ceafc642"
-  integrity sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==
+  integrity sha512-phP48e8AawgsNUjEY2WvoIWqdie8PoiDZGxTDv70LDr01uX5wLEQbOgSP7Z/B6+SW5oLtbe8qaYX2fKJs3CGTw==
 
 type-fest@^0.13.1:
   version "0.13.1"
@@ -3132,27 +3145,22 @@ type-fest@^0.8.1:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-  integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+  integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-underscore@1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
-  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
-
-underscore@>=1.8.3:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
-  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
+underscore@>=1.8.3, underscore@~1.13.6:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
+  integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
 underscore@~1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
-  integrity sha1-izixDKze9jM3uLJOT/htRa6lKag=
+  integrity sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==
 
 union-find@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/union-find/-/union-find-1.0.2.tgz#292bac415e6ad3a89535d237010db4a536284e58"
-  integrity sha1-KSusQV5q06iVNdI3AQ20pTYoTlg=
+  integrity sha512-wFA9bMD/40k7ZcpKVXfu6X1qD3ri5ryO8HUsuA1RnxPCQl66Mu6DgkxyR+XNnd+osD0aLENixcJVFj+uf+O4gw==
 
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"
@@ -3164,7 +3172,7 @@ unist-util-stringify-position@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 uuidjs@^3.3.0:
   version "3.6.2"
@@ -3241,17 +3249,17 @@ webcola@^3.4.0:
 wgs84@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/wgs84/-/wgs84-0.0.0.tgz#34fdc555917b6e57cf2a282ed043710c049cdc76"
-  integrity sha1-NP3FVZF7blfPKigu0ENxDASc3HY=
+  integrity sha512-ANHlY4Rb5kHw40D0NJ6moaVfOCMrp9Gpd1R/AIQYg2ko4/jzcJ+TVXYYF6kXJqQwITvEZP4yEthjM7U6rYlljQ==
 
 wkt-parser@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/wkt-parser/-/wkt-parser-1.3.1.tgz#a569678eb28f82f6739f736319be073e32bf8191"
-  integrity sha512-XK5qV+Y5gsygQfHx2/cS5a7Zxsgleaw8iX5UPC5eOXPc0TgJAu1JB9lr0iYYX3zAnN3p0aNiaN5c+1Bdblxwrg==
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/wkt-parser/-/wkt-parser-1.3.3.tgz#46b4e3032dd9c86907f7e630b57e3c6ea2bb772b"
+  integrity sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw==
 
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
A handful of updates needed for compatibility with v6.2.4, including re-exports of the resource model graphs.

Two notes about this update:

1. For some reason I had to add `leaflet-side-by-side.js` into `media/js`, before that it wasn't found by the iiif-viewer component.
2. In staging, there is a lingering issue with the `resource-type-filter` in the search map.